### PR TITLE
add support for funny names

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,9 @@ in the configuration file
     - Delete<Entity>
         - Given the id of an entity, Delete<Entity> deletes it and returns an error on failure or
           nil on success.
+    - BulkDelete<Entity>
+        - Given a list of entity ids, deletes all of the entities and returns an error on failure
+          or nil on success.
     - <Entity>FillAll
         - Given an entity, <Entity>FillAll fills in all the attached decendant entities.
           For entities without children, this is a no-op. This method is recursive, so

--- a/gen/gen_query.go
+++ b/gen/gen_query.go
@@ -39,7 +39,7 @@ func (g *Generator) genQuery(
 	g.infof("		generating query '%s'\n", config.Name)
 
 	// ensure that the query name is in the right format for go
-	config.Name = snakeToPascal(config.Name)
+	config.Name = pgToGoName(config.Name)
 
 	// not needed, but it does make the generated code a little nicer
 	config.Body = strings.TrimSpace(config.Body)

--- a/gen/gen_stmt.go
+++ b/gen/gen_stmt.go
@@ -28,7 +28,7 @@ func (g *Generator) genStmts(into io.Writer, stmts []stmtConfig) error {
 func (g *Generator) genStmt(into io.Writer, stmt *stmtConfig) error {
 	g.infof("		generating statement '%s'\n", stmt.Name)
 
-	stmt.Name = snakeToPascal(stmt.Name)
+	stmt.Name = pgToGoName(stmt.Name)
 
 	meta, err := g.stmtMeta(stmt)
 	if err != nil {

--- a/gen/gen_table.go
+++ b/gen/gen_table.go
@@ -185,7 +185,7 @@ func (p *PGClient) List{{ .GoName }}(
 ) ([]{{ .GoName }}, error) {
 	rows, err := p.DB.QueryContext(
 		ctx,
-		"SELECT * FROM \"{{ .PgName }}\" WHERE {{ .PkeyCol.PgName }} = ANY($1)",
+		"SELECT * FROM \"{{ .PgName }}\" WHERE \"{{ .PkeyCol.PgName }}\" = ANY($1)",
 		pq.Array(ids),
 	)
 	if err != nil {
@@ -243,7 +243,7 @@ func (p *PGClient) BulkInsert{{ .GoName }}(
 	var fields []string = []string{
 		{{- range .Cols }}
 		{{- if (not .IsPrimary) }}
-		"{{ .PgName }}",
+		` + "`" + `{{ .PgName }}` + "`" + `,
 		{{- end }}
 		{{- end }}
 	}
@@ -306,7 +306,7 @@ func (p *PGClient) Update{{ .GoName }}(
 ) (ret {{ .PkeyCol.TypeInfo.Name }}, err error) {
 	var fields []string = []string{
 		{{- range .Cols }}
-		"{{ .PgName }}",
+		` + "`" + `{{ .PgName }}` + "`" + `,
 		{{- end }}
 	}
 
@@ -357,7 +357,7 @@ func (p *PGClient) BulkDelete{{ .GoName }}(
 ) error {
 	res, err := p.DB.ExecContext(
 		ctx,
-		"DELETE FROM \"{{ .PgName }}\" WHERE {{ .PkeyCol.PgName }} = ANY($1)",
+		"DELETE FROM \"{{ .PgName }}\" WHERE \"{{ .PkeyCol.PgName }}\" = ANY($1)",
 		pq.Array(ids),
 	)
 	if err != nil {
@@ -381,7 +381,7 @@ func (p *PGClient) BulkDelete{{ .GoName }}(
 }
 
 var {{ .GoName }}AllIncludes *include.Spec = include.Must(include.Parse(
-	"{{ .AllIncludeSpec }}",
+	` + "`" + `{{ .AllIncludeSpec }}` + "`" + `,
 ))
 func (p *PGClient) {{ .GoName }}FillAll(
 	ctx context.Context,
@@ -632,7 +632,7 @@ func buildExplicitBelongsToMapping(
 			pointsToMeta := infoTab[belongsTo.Table].meta
 			ref := refMeta{
 				PgPointsTo: belongsTo.Table,
-				GoPointsTo: snakeToPascal(inflection.Singular(belongsTo.Table)),
+				GoPointsTo: pgToGoName(inflection.Singular(belongsTo.Table)),
 				PointsToFields: []fieldNames{
 					{
 						PgName: pointsToMeta.PkeyCol.PgName,
@@ -640,12 +640,12 @@ func buildExplicitBelongsToMapping(
 					},
 				},
 				PgPointsFrom:       table.Name,
-				GoPointsFrom:       snakeToPascal(inflection.Singular(table.Name)),
-				PluralGoPointsFrom: snakeToPascal(table.Name),
+				GoPointsFrom:       pgToGoName(inflection.Singular(table.Name)),
+				PluralGoPointsFrom: pgToGoName(table.Name),
 				PointsFromFields: []fieldNames{
 					{
 						PgName: belongsTo.KeyField,
-						GoName: snakeToPascal(belongsTo.KeyField),
+						GoName: pgToGoName(belongsTo.KeyField),
 					},
 				},
 				OneToOne: belongsTo.OneToOne,

--- a/gen/name_conversion.go
+++ b/gen/name_conversion.go
@@ -12,16 +12,19 @@ import (
 // with a given stored function or prepared statement.
 //
 
-// Convert a snake_case name to a PascalCaseName
-func snakeToPascal(snakeName string) string {
-	return snakeToMixed(snakeName, true)
-}
+// Convert a postgres name (assumed to be snake_case)
+// to a PascalCaseName
+func pgToGoName(snakeName string) string {
+	needsUpper := true
 
-func snakeToMixed(snakeName string, needsUpper bool) string {
 	var res strings.Builder
 	for _, r := range snakeName {
-		if r == '_' {
+		if unicode.IsSpace(r) {
+			continue
+		} else if r == '_' {
 			needsUpper = true
+		} else if unicode.IsPunct(r) {
+			continue
 		} else if needsUpper {
 			res.WriteRune(unicode.ToUpper(r))
 			needsUpper = false

--- a/gen/name_conversion_test.go
+++ b/gen/name_conversion_test.go
@@ -1,0 +1,42 @@
+package gen
+
+import (
+	"testing"
+)
+
+func TestPgToGoName(t *testing.T) {
+	type testCase struct {
+		src      string
+		expected string
+	}
+
+	cases := []testCase{
+		{
+			src:      "foo_bar",
+			expected: "FooBar",
+		},
+		{
+			src:      "foo",
+			expected: "Foo",
+		},
+		{
+			src:      "fooBar",
+			expected: "FooBar",
+		},
+		{
+			src:      "foo Bar",
+			expected: "FooBar",
+		},
+		{
+			src:      "foo?!#_bar",
+			expected: "FooBar",
+		},
+	}
+
+	for i, c := range cases {
+		actual := pgToGoName(c.src)
+		if actual != c.expected {
+			t.Fatalf("case %d: expected '%s', got '%s'", i, c.expected, actual)
+		}
+	}
+}

--- a/gen/tables.go
+++ b/gen/tables.go
@@ -28,8 +28,8 @@ func (g *Generator) typeInfoOf(pgTypeName string) (goTypeInfo, error) {
 	// if there are no variants, then it is not an enum
 	if len(variants) > 0 {
 		typeInfo := goTypeInfo{
-			Name:        snakeToPascal(pgTypeName),
-			NullName:    "*" + snakeToPascal(pgTypeName),
+			Name:        pgToGoName(pgTypeName),
+			NullName:    "*" + pgToGoName(pgTypeName),
 			SqlReceiver: refWrap,
 		}
 
@@ -62,7 +62,7 @@ const (
 		var evs []enumVar
 		for _, v := range variants {
 			evs = append(evs, enumVar{
-				GoName: snakeToPascal(v),
+				GoName: pgToGoName(v),
 				PgName: v,
 			})
 		}

--- a/include/include_test.go
+++ b/include/include_test.go
@@ -70,6 +70,23 @@ func TestParseSuccess(t *testing.T) {
 			src:    "  foos.{bars .blip. flip.dip ,bim.{a, b   ,c.{d   ,    e}}}    ",
 			result: "foos.{bars.blip.flip.dip,bim.{a,b,c.{d,e}}}",
 		},
+		// funny names
+		{
+			src: "f$",
+		},
+		{
+			src: "_f",
+		},
+		{
+			src:    `"foo"`,
+			result: `foo`,
+		},
+		{
+			src: `"123 _f"`,
+		},
+		{
+			src: `"123 "" _f"`,
+		},
 	}
 
 	for i, c := range cases {
@@ -137,6 +154,10 @@ func TestParseErrors(t *testing.T) {
 		{
 			src: "foos.{}",
 			re:  "empty spec list",
+		},
+		{
+			src: `"blah balhjl`,
+			re:  "unexpected end of input in quoted identifier",
 		},
 	}
 

--- a/pggen/test/cli_test.go
+++ b/pggen/test/cli_test.go
@@ -105,6 +105,15 @@ name = "small_entities"
 		exitCode: 1,
 		stderrRE: "while parsing config file",
 	},
+	{
+		// missing table
+		toml: `
+[[table]]
+    name = "dne"
+		`,
+		exitCode: 1,
+		stderrRE: "could not find table 'dne' in the database",
+	},
 }
 
 func TestCLI(t *testing.T) {

--- a/pggen/test/db.sql
+++ b/pggen/test/db.sql
@@ -129,6 +129,25 @@ CREATE TABLE explicit_belongs_to_many (
     small_entity_id integer NOT NULL
 );
 
+-- SQL has the best identifier rules. Sigh. Let's support them.
+-- At least you don't seem to be able to start with a number
+-- without quoting.
+CREATE TABLE "Weird NaMeS" (
+    "even id is weird" SERIAL PRIMARY KEY,
+    WeAreTalking___REALLY_badstyle integer NOT NULL,
+    "Got Whitespace?" text NOT NULL,
+    "But
+    Why
+    Tho" integer
+);
+
+CREATE TABLE "Weird?! Kid" (
+    "space id" SERIAL PRIMARY KEY,
+    "Daddy" integer NOT NULL
+        REFERENCES "Weird NaMeS"("even id is weird")
+            ON DELETE RESTRICT ON UPDATE CASCADE
+);
+
 --
 -- Load Data
 --

--- a/pggen/test/pggen.toml
+++ b/pggen/test/pggen.toml
@@ -217,6 +217,12 @@
         table = "small_entities"
         key_field = "small_entity_id"
 
+[[table]]
+    name = "Weird NaMeS"
+
+[[table]]
+    name = "Weird?! Kid"
+
 # TODO: it would be nice to support `INSERT ... RETURNING ...` queries, but
 #       that breaks the way that we use tmp views to infer the result types
 #       of queries. At the very least we should throw an error for queries


### PR DESCRIPTION
SQL allows identifiers to be pretty strange through
the use of quoted identifiers. There were previously
a fair number of assumptions baked into the pggen codebase
about sql identifiers being fairly sensible, but we are
dealing with a COBOL flavored language so that isn't
a reasonable assumption.

This patch fixes all those assumptions.

Closes #3