### PR TITLE
use native nulls in public interface

### DIFF
--- a/cmd/pggen/test/gorm_compat_test.go
+++ b/cmd/pggen/test/gorm_compat_test.go
@@ -55,12 +55,12 @@ func TestGormPreload(t *testing.T) {
 		"text 3": true,
 	}
 	for _, a := range smallEntity.Attachments {
-		if !a.Value.Valid {
+		if a.Value == nil {
 			t.Fatalf("unexpected null")
 		}
 
-		if !allowedValues[a.Value.String] {
-			t.Fatalf("unexpected value: '%s'", a.Value.String)
+		if !allowedValues[*a.Value] {
+			t.Fatalf("unexpected value: '%s'", *a.Value)
 		}
 	}
 }

--- a/cmd/pggen/test/queries_test.go
+++ b/cmd/pggen/test/queries_test.go
@@ -3,6 +3,7 @@ package test
 import (
 	"fmt"
 	"reflect"
+	"regexp"
 	"testing"
 	"time"
 
@@ -25,7 +26,7 @@ func TestMixedNullText(t *testing.T) {
 		call: func() (interface{}, error) {
 			return pgClient.MixedNullText(ctx)
 		},
-		expected: `\[.*String":"foo".*Valid":true.*Valid":false.*\]`,
+		expected: `\["foo",null\]`,
 	}.test(t)
 }
 
@@ -34,7 +35,7 @@ func TestMultiReturn(t *testing.T) {
 		call: func() (interface{}, error) {
 			return pgClient.MultiReturn(ctx)
 		},
-		expected: `\[.*String":"foo".*Int64":1.*Valid":false.*Valid":false.*\]`,
+		expected: `\[.*TextField":"foo".*SmallintField":1.*TextField":null.*SmallintField":null.*\]`,
 	}.test(t)
 }
 
@@ -43,7 +44,7 @@ func TestTextArg(t *testing.T) {
 		call: func() (interface{}, error) {
 			return pgClient.TextArg(ctx, "foo")
 		},
-		expected: `\[.*"String":"foo".*\]`,
+		expected: `\["foo"\]`,
 	}.test(t)
 
 	Expectation{
@@ -59,7 +60,7 @@ func TestMoneyArg(t *testing.T) {
 		call: func() (interface{}, error) {
 			return pgClient.MoneyArg(ctx, "3.50")
 		},
-		expected: `\[.*String":"\$3.50".*\]`,
+		expected: `\["\$3.50"\]`,
 	}.test(t)
 }
 
@@ -71,7 +72,7 @@ func TestDateTimeArg(t *testing.T) {
 		call: func() (interface{}, error) {
 			return pgClient.DateTimeArg(ctx, early, early, early)
 		},
-		expected: `\[.*"Time":"1999-01-08T04:05:06Z".*\]`,
+		expected: `\["1999-01-08T04:05:06Z"\]`,
 	}.test(t)
 
 	Expectation{
@@ -87,7 +88,7 @@ func TestBooleanArg(t *testing.T) {
 		call: func() (interface{}, error) {
 			return pgClient.BooleanArg(ctx, true)
 		},
-		expected: `\[.*"Bool":true.*\]`,
+		expected: `\[true\]`,
 	}.test(t)
 }
 
@@ -96,7 +97,7 @@ func TestEnumArg(t *testing.T) {
 		call: func() (interface{}, error) {
 			return pgClient.EnumArg(ctx, db_shims.EnumTypeOption1)
 		},
-		expected: `\[.*EnumType":"option1","Valid":true.*\]`,
+		expected: `\["option1"\]`,
 	}.test(t)
 }
 
@@ -107,7 +108,7 @@ func TestUUIDArg(t *testing.T) {
 		call: func() (interface{}, error) {
 			return pgClient.UUIDArg(ctx, uuid.Must(uuid.FromString(id)))
 		},
-		expected: fmt.Sprintf(`\[.*"UUID":"%s".*\]`, id),
+		expected: fmt.Sprintf(`\["%s"\]`, id),
 	}.test(t)
 }
 
@@ -126,7 +127,7 @@ func TestNumbersArgs(t *testing.T) {
 			return pgClient.NumberArgs(
 				ctx, 0, 0, 0, "0", "0", "0", "0", 0.0, 0.0, 0, 0)
 		},
-		expected: `\[.*Int64":1.*\]`,
+		expected: `\[1\]`,
 	}.test(t)
 }
 
@@ -150,7 +151,7 @@ func TestListText(t *testing.T) {
 		call: func() (interface{}, error) {
 			return pgClient.ListText(ctx, ids)
 		},
-		expected: `\[.*String":"foo".*Valid":true.*Valid":false.*\]`,
+		expected: `\["foo",null\]`,
 	}.test(t)
 }
 
@@ -159,7 +160,7 @@ func TestRollUpNums(t *testing.T) {
 		call: func() (interface{}, error) {
 			return pgClient.RollUpNums(ctx)
 		},
-		expected: `Int64":3.*Int64":0.*String":"15.4.*String":"".*`,
+		expected: regexp.QuoteMeta(`[{"Ints":[3,null],"Decs":["15.4",null]}]`),
 	}.test(t)
 }
 
@@ -171,7 +172,7 @@ func TestEnumArrays(t *testing.T) {
 				[]db_shims.EnumType{"option1", "option2"},
 			)
 		},
-		expected: `"option2","Valid":true.*"option1","Valid":true`,
+		expected: regexp.QuoteMeta(`[["option2","option1"]]`),
 	}.test(t)
 
 	Expectation{
@@ -181,6 +182,6 @@ func TestEnumArrays(t *testing.T) {
 				[]db_shims.EnumType{"option1", "option2"},
 			)
 		},
-		expected: `"option1","Valid":true.*"","Valid":false`,
+		expected: regexp.QuoteMeta(`[["option1",null]]`),
 	}.test(t)
 }

--- a/cmd/pggen/test/tables_test.go
+++ b/cmd/pggen/test/tables_test.go
@@ -214,14 +214,14 @@ func TestFillAll(t *testing.T) {
 	foo := "foo"
 	attachmentID1, err := txClient.InsertAttachment(ctx, db_shims.Attachment{
 		SmallEntityId: entityID,
-		Value:         sql.NullString{String: foo, Valid: true},
+		Value:         &foo,
 	})
 	chkErr(t, err)
 
 	bar := "bar"
 	attachmentID2, err := txClient.InsertAttachment(ctx, db_shims.Attachment{
 		SmallEntityId: entityID,
-		Value:         sql.NullString{String: bar, Valid: true},
+		Value:         &bar,
 	})
 	chkErr(t, err)
 
@@ -274,7 +274,7 @@ func TestFillIncludes(t *testing.T) {
 	foo := "foo"
 	attachmentID1, err := txClient.InsertAttachment(ctx, db_shims.Attachment{
 		SmallEntityId: entityID,
-		Value:         sql.NullString{String: foo, Valid: true},
+		Value:         &foo,
 	})
 	chkErr(t, err)
 
@@ -358,10 +358,11 @@ func TestFunnyNamesInTableGeneratedFunc(t *testing.T) {
 		_ = txClient.DB.(*sql.Tx).Rollback()
 	}()
 
+	var nineteen int64 = 19
 	funnyID, err := txClient.InsertWeirdNaMe(ctx, db_shims.WeirdNaMe{
 		WearetalkingReallyBadstyle: 1923,
 		GotWhitespace:              "yes",
-		ButWhyTho:                  sql.NullInt64{Int64: 19, Valid: true},
+		ButWhyTho:                  &nineteen,
 	})
 	chkErr(t, err)
 
@@ -401,12 +402,10 @@ func TestArrayMembers(t *testing.T) {
 		_ = txClient.DB.(*sql.Tx).Rollback()
 	}()
 
+	var nineteen int64 = 19
 	id, err := txClient.InsertArrayMember(ctx, db_shims.ArrayMember{
 		TextArray: []string{"foo", "bar"},
-		IntArray: []sql.NullInt64{
-			{Int64: 19, Valid: true},
-			{},
-		},
+		IntArray:  []*int64{&nineteen, nil},
 	})
 	chkErr(t, err)
 

--- a/gen/gen.go
+++ b/gen/gen.go
@@ -225,7 +225,9 @@ import (
 	}
 	sortedPkgs := make([]string, len(g.imports))[:0]
 	for pkg := range g.imports {
-		sortedPkgs = append(sortedPkgs, pkg)
+		if len(pkg) > 0 {
+			sortedPkgs = append(sortedPkgs, pkg)
+		}
 	}
 	sort.Strings(sortedPkgs)
 	for _, pkg := range sortedPkgs {

--- a/gen/gen_prelude.go
+++ b/gen/gen_prelude.go
@@ -32,8 +32,11 @@ var preludeTmpl *template.Template = template.Must(template.New("prelude-tmpl").
 package {{ .Pkg }}
 
 import (
-	"strings"
+	"database/sql"
 	"fmt"
+	"strings"
+	"time"
+	uuid "github.com/satori/go.uuid"
 
 	"github.com/opendoor-labs/pggen"
 )
@@ -149,5 +152,47 @@ func genUpdateStmt(
 
 func parenWrap(in string) string {
 	return "(" + in + ")"
+}
+
+func convertNullString(s sql.NullString) *string {
+	if s.Valid {
+		return &s.String
+	}
+	return nil
+}
+
+func convertNullBool(b sql.NullBool) *bool {
+	if b.Valid {
+		return &b.Bool
+	}
+	return nil
+}
+
+func convertNullTime(t sql.NullTime) *time.Time {
+	if t.Valid {
+		return &t.Time
+	}
+	return nil
+}
+
+func convertNullFloat64(f sql.NullFloat64) *float64 {
+	if f.Valid {
+		return &f.Float64
+	}
+	return nil
+}
+
+func convertNullInt64(i sql.NullInt64) *int64 {
+	if i.Valid {
+		return &i.Int64
+	}
+	return nil
+}
+
+func convertNullUUID(u uuid.NullUUID) *uuid.UUID {
+	if u.Valid {
+		return &u.UUID
+	}
+	return nil
 }
 `))


### PR DESCRIPTION
This patch switches the public interface of pggen's
generated code to use native go pointers rather than
`sql.Null*` types. This might have a small performance
impact, but it should make for more ergonomic code.

Closes #27