### PR TITLE
add Upsert method

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -63,3 +63,44 @@ itself. You can enable re-running the cli tests with
 This will both prevent the cli tests from removing their scratch dir and
 compile the binary under test in a debugger friendly format so that you can
 immediately point your delve at it.
+
+## Errors in the Generated Code
+
+When modifying the output of the codegenerator, you are likely to introduce compile
+errors in the generated code. Because we run the `go/format` package over our output
+before landing it to a disk you won't be able to debug the issue by looking at the
+generated file by default. In order to make this easier, you can modify the `writeGoFile`
+routine in `gen/utils.go` to skip the formatting and just dump the code to disk.
+
+```
+
+diff --git a/gen/utils.go b/gen/utils.go
+index dd7804d..77a437e 100644
+--- a/gen/utils.go
++++ b/gen/utils.go
+@@ -2,7 +2,7 @@ package gen
+
+ import (
+ 	"fmt"
+-	"go/format"
++	// "go/format"
+ 	"io"
+ 	"math/rand"
+ 	"os"
+@@ -18,10 +18,13 @@ func writeGoFile(path string, src []byte) error {
+ 	}
+ 	defer outFile.Close()
+
++	/*
+ 	formattedSrc, err := format.Source(src)
+ 	if err != nil {
+ 		return fmt.Errorf("internal pggen error: %s", err.Error())
+ 	}
++	*/
++	formattedSrc := src
+
+ 	return writeCompletely(outFile, formattedSrc)
+ }
+```
+
+Even without formatting it is actually pretty readable.

--- a/README.md
+++ b/README.md
@@ -289,6 +289,17 @@ in the configuration file
         - Given an entity struct and a bitset, Update<Entity> updates all the fields of the
           given struct with their corresponding bit set in the database and returns the
           primary key of the updated record.
+    - Upsert<Entity>
+        - Given an entity, a list of conflict targets, and a bitset, Upsert<Entity> tries
+          to insert the given entity. A nil list of conflict targets will default to the primary
+          key for the table. If the bit for the primary key is set in the bitset
+          it will try to insert the primary key from the provided entity, otherwise it will
+          let the database supply a new primary key. In the event of a conflict on any of the
+          provided conflict targets, Upsert<Entity> will update only those fields which are
+          specified by the given bitset.
+    - BulkUpsert<Entity>
+        - BulkUpsert<Entity> behaves exactly like Upsert<Entity> except that it operates on
+          whole a set of entities at once.
     - Delete<Entity>
         - Given the id of an entity, Delete<Entity> deletes it and returns an error on failure or
           nil on success.

--- a/cmd/pggen/test/db.sql
+++ b/cmd/pggen/test/db.sql
@@ -191,6 +191,12 @@ CREATE TABLE "Weird?! Kid" (
             ON DELETE RESTRICT ON UPDATE CASCADE
 );
 
+CREATE TABLE constraints (
+    id SERIAL PRIMARY KEY,
+    snowflake int NOT NULL UNIQUE,
+    other int NOT NULL
+);
+
 --
 -- Load Data
 --

--- a/cmd/pggen/test/pggen.toml
+++ b/cmd/pggen/test/pggen.toml
@@ -285,3 +285,6 @@
 
 [[table]]
     name = "col_order"
+
+[[table]]
+    name = "constraints"

--- a/gen/metadata.go
+++ b/gen/metadata.go
@@ -418,6 +418,8 @@ type tableMeta struct {
 	HasUpdateAtField bool
 	// If true, this table does have a create timestamp field
 	HasCreatedAtField bool
+	// The 0-based index of the primary key column
+	PkeyColIdx int
 }
 
 // colMeta contains metadata about postgres table columns such column
@@ -515,7 +517,10 @@ func (g *Generator) tableMeta(table string) (tableMeta, error) {
 		)
 	}
 
-	var pkeyCol *colMeta
+	var (
+		pkeyCol    *colMeta
+		pkeyColIdx int
+	)
 	for i, c := range cols {
 		if c.IsPrimary {
 			if pkeyCol != nil {
@@ -523,14 +528,16 @@ func (g *Generator) tableMeta(table string) (tableMeta, error) {
 			}
 
 			pkeyCol = &cols[i]
+			pkeyColIdx = i
 		}
 	}
 
 	meta := tableMeta{
-		PgName:  table,
-		GoName:  pgTableToGoModel(table),
-		PkeyCol: pkeyCol,
-		Cols:    cols,
+		PgName:     table,
+		GoName:     pgTableToGoModel(table),
+		PkeyCol:    pkeyCol,
+		PkeyColIdx: pkeyColIdx,
+		Cols:       cols,
 	}
 	err = g.fillTableReferences(&meta)
 	if err != nil {

--- a/pggen.go
+++ b/pggen.go
@@ -57,3 +57,8 @@ func (fs FieldSet) Set(bit int, value bool) FieldSet {
 func (fs FieldSet) Test(bit int) bool {
 	return fs.b.Test(uint(bit))
 }
+
+// Return the number of bits set to 1
+func (fs FieldSet) CountSetBits() int {
+	return int(fs.b.Count())
+}


### PR DESCRIPTION
This patch adds new Upsert and BulkUpsert methods to the generated
PGClient. The upsert only triggers on primary key conflicts for now,
though we could conceivably expose a lower level API which allows
tuning of which constraints the upsert gets trigger for.

Closes #44