### PR TITLE
fix bug in the way that cyclic data is loaded

### DIFF
--- a/cmd/pggen/test/db.sql
+++ b/cmd/pggen/test/db.sql
@@ -221,6 +221,54 @@ CREATE TABLE enum_blanks (
     value enum_type_with_blank NOT NULL
 );
 
+
+-- cyclical references
+CREATE TABLE cycle1 (
+    id SERIAL PRIMARY KEY,
+    value text NOT NULL
+);
+CREATE TABLE cycle2 (
+    id SERIAL PRIMARY KEY,
+    value int NOT NULL,
+    cycle1_id integer NOT NULL REFERENCES cycle1(id)
+);
+ALTER TABLE cycle1 ADD COLUMN cycle2_id integer REFERENCES cycle2(id);
+
+-- an object tree with a cycle in the branches that is reached by multiple
+-- branch paths
+CREATE TABLE cycle_tree_root (
+    id SERIAL PRIMARY KEY,
+    value text NOT NULL
+);
+CREATE TABLE cycle_tree_branch1 (
+    id SERIAL PRIMARY KEY,
+    value text NOT NULL,
+    cycle_tree_root_id integer NOT NULL REFERENCES cycle_tree_root(id)
+);
+CREATE TABLE cycle_tree_branch2 (
+    id SERIAL PRIMARY KEY,
+    value text NOT NULL,
+    cycle_tree_root_id integer NOT NULL UNIQUE REFERENCES cycle_tree_root(id)
+);
+CREATE TABLE cycle_tree_cycle1 (
+    id SERIAL PRIMARY KEY,
+    value text NOT NULL,
+    cycle_tree_branch1_id integer NOT NULL UNIQUE REFERENCES cycle_tree_branch1(id)
+);
+CREATE TABLE cycle_tree_cycle2 (
+    id SERIAL PRIMARY KEY,
+    value text NOT NULL,
+    cycle_tree_cycle1_id integer NOT NULL UNIQUE REFERENCES cycle_tree_cycle1(id),
+    cycle_tree_branch2_id integer NOT NULL UNIQUE REFERENCES cycle_tree_branch2(id)
+);
+CREATE TABLE cycle_tree_cycle3 (
+    id SERIAL PRIMARY KEY,
+    value text NOT NULL,
+    cycle_tree_cycle2_id integer NOT NULL UNIQUE REFERENCES cycle_tree_cycle2(id)
+);
+ALTER TABLE cycle_tree_cycle1 ADD COLUMN
+    cycle_tree_cycle3_id integer REFERENCES cycle_tree_cycle3(id);
+
 --
 -- Load Data
 --

--- a/cmd/pggen/test/pggen.toml
+++ b/cmd/pggen/test/pggen.toml
@@ -300,3 +300,21 @@
 
 [[table]]
     name = "enum_blanks"
+
+[[table]]
+    name = "cycle1"
+[[table]]
+    name = "cycle2"
+
+[[table]]
+    name = "cycle_tree_root"
+[[table]]
+    name = "cycle_tree_branch1"
+[[table]]
+    name = "cycle_tree_branch2"
+[[table]]
+    name = "cycle_tree_cycle1"
+[[table]]
+    name = "cycle_tree_cycle2"
+[[table]]
+    name = "cycle_tree_cycle3"

--- a/gen/metadata.go
+++ b/gen/metadata.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/jinzhu/inflection"
 	"github.com/lib/pq"
 )
 
@@ -137,7 +136,7 @@ func (g *Generator) stmtMeta(
 // and uses that to generate a list of argument metadata
 func (g *Generator) argsOfStmt(body string) ([]arg, error) {
 	// Connections require a context, so we'll use a dummy
-	ctx := context.TODO()
+	ctx := context.Background()
 
 	// prepared statements are scoped to the database session
 	// (the tcp connection to postgres, or connection in go terms)
@@ -406,8 +405,9 @@ func (g *Generator) queryReturns(query string) ([]colMeta, error) {
 
 // tableMeta contains metadata about a postgres table
 type tableMeta struct {
-	PgName string
-	GoName string
+	PgName       string
+	GoName       string
+	PluralGoName string
 	// metadata for the primary key column
 	PkeyCol *colMeta
 	// Metadata about the tables columns
@@ -425,35 +425,39 @@ type tableMeta struct {
 // colMeta contains metadata about postgres table columns such column
 // names, types, nullability, default...
 type colMeta struct {
-	ColNum      int32
-	GoName      string
-	PgName      string
-	PgType      string
-	TypeInfo    goTypeInfo
-	Nullable    bool
+	// postgres's internal column number for this column
+	ColNum int32
+	// the name of the field in the go struct which corresponds to this column
+	GoName string
+	// the name of this column in postgres
+	PgName string
+	// name of the type of this column
+	PgType string
+	// a more descriptive record of the type of this column
+	TypeInfo goTypeInfo
+	// true if this column can be null
+	Nullable bool
+	// the postgres default value for this column
 	DefaultExpr string
-	IsPrimary   bool
+	// true if this column is the primary key for this table
+	IsPrimary bool
+	// true if this column has a UNIQUE index on it
+	IsUnique bool
 }
 
 // refMeta contains metadata for a reference between two tables
 // (a foreign key relationship)
 type refMeta struct {
-	// The name of the table that this reference is referring to
-	PgPointsTo string
-	// The name of the go struct which corresponds to PgPointsTo
-	GoPointsTo string
+	// The metadata for the table that holds the foreign key
+	PointsTo *tableMeta
 	// The names of the fields in the referenced table that are used as keys
 	// (usually the primary keys of that table). Order matters.
-	PointsToFields []fieldNames
-	// The name of the table that is referring to another table
-	PgPointsFrom string
-	// The name of the go struct which corresponds to PgPointsFrom
-	GoPointsFrom string
-	// A pluralized version of GoPointsFrom
-	PluralGoPointsFrom string
+	PointsToFields []*colMeta
+	// The metadata for the table is being referred to
+	PointsFrom *tableMeta
 	// The names of the fields that are being used to refer to the key fields
 	// for the referenced table. Order matters.
-	PointsFromFields []fieldNames
+	PointsFromFields []*colMeta
 	// Indicates that there can be at most one of these references between
 	// the two tables.
 	OneToOne bool
@@ -462,21 +466,27 @@ type refMeta struct {
 	Nullable bool
 }
 
-type fieldNames struct {
-	PgName string
-	GoName string
-}
-
 // Given the name of a table returns metadata about it
 func (g *Generator) tableMeta(table string) (tableMeta, error) {
 	rows, err := g.db.Query(`
+		WITH unique_cols AS (
+			SELECT
+				UNNEST(ix.indkey) as colnum,
+				ix.indisunique as is_unique
+			FROM pg_class c
+			JOIN pg_index ix
+				ON (c.oid = ix.indrelid)
+			WHERE c.relname = $1
+		)
+
 		SELECT
 			a.attnum AS col_num,
 			a.attname AS col_name,
 			format_type(a.atttypid, a.atttypmod) AS col_type,
 			NOT a.attnotnull AS nullable,
 			COALESCE(pg_get_expr(ad.adbin, ad.adrelid), '') AS default_expr,
-			COALESCE(ct.contype = 'p', false) AS is_primary
+			COALESCE(ct.contype = 'p', false) AS is_primary,
+			COALESCE(u.is_unique, 'f'::bool) AS is_unique
 		FROM pg_attribute a
 		INNER JOIN pg_class c
 			ON (c.oid = a.attrelid)
@@ -484,6 +494,8 @@ func (g *Generator) tableMeta(table string) (tableMeta, error) {
 			ON (ct.conrelid = c.oid AND a.attnum = ANY(ct.conkey) AND ct.contype = 'p')
 		LEFT JOIN pg_attrdef ad
 			ON (ad.adrelid = c.oid AND ad.adnum = a.attnum)
+		LEFT JOIN unique_cols u
+			ON (u.colnum = a.attnum)
 		WHERE a.attisdropped = false AND c.relname = $1 AND (a.attnum > 0)
 		ORDER BY a.attnum
 		`, table)
@@ -501,6 +513,7 @@ func (g *Generator) tableMeta(table string) (tableMeta, error) {
 			&col.Nullable,
 			&col.DefaultExpr,
 			&col.IsPrimary,
+			&col.IsUnique,
 		)
 		if err != nil {
 			return tableMeta{}, err
@@ -535,27 +548,20 @@ func (g *Generator) tableMeta(table string) (tableMeta, error) {
 		}
 	}
 
-	meta := tableMeta{
-		PgName:     table,
-		GoName:     pgTableToGoModel(table),
-		PkeyCol:    pkeyCol,
-		PkeyColIdx: pkeyColIdx,
-		Cols:       cols,
-	}
-	err = g.fillTableReferences(&meta)
-	if err != nil {
-		return tableMeta{}, err
-	}
-
-	return meta, nil
+	return tableMeta{
+		PgName:       table,
+		GoName:       pgTableToGoModel(table),
+		PluralGoName: pgToGoName(table),
+		PkeyCol:      pkeyCol,
+		PkeyColIdx:   pkeyColIdx,
+		Cols:         cols,
+	}, nil
 }
 
 // Given a tableMeta with the PgName and Cols already filled out, fill in the
-// References list
+// References list. Any tables which are referenced by the given table must
+// already be loaded into `g.tables`.
 func (g *Generator) fillTableReferences(meta *tableMeta) error {
-	// This runs N+1 queries where N is the number of foreign keys referencing
-	// the given table. We might be able to do better with UNNEST hacks, but
-	// I'm not sure how worth it that would be. Also, N is likely to be small.
 	rows, err := g.db.Query(`
 		SELECT
 			pt.relname as points_to,
@@ -574,19 +580,27 @@ func (g *Generator) fillTableReferences(meta *tableMeta) error {
 		return err
 	}
 	for rows.Next() {
+
+		var (
+			pgPointsTo   string
+			pgPointsFrom string
+		)
+
 		pointsToIdxs := []int64{}
 		pointsFromIdxs := []int64{}
 		var ref refMeta
 		err = rows.Scan(
-			&ref.PgPointsTo, pq.Array(&pointsToIdxs),
-			&ref.PgPointsFrom, pq.Array(&pointsFromIdxs),
+			&pgPointsTo, pq.Array(&pointsToIdxs),
+			&pgPointsFrom, pq.Array(&pointsFromIdxs),
 		)
 		if err != nil {
 			return err
 		}
-		ref.GoPointsTo = pgTableToGoModel(ref.PgPointsTo)
-		ref.PluralGoPointsFrom = pgToGoName(ref.PgPointsFrom)
-		ref.GoPointsFrom = inflection.Singular(ref.PluralGoPointsFrom)
+
+		_, inTOMLConfig := g.tables[pgPointsFrom]
+		if !inTOMLConfig {
+			continue
+		}
 
 		for _, idx := range pointsToIdxs {
 			// attnum is 1-based, so we will first convert it into a 0-based
@@ -596,93 +610,32 @@ func (g *Generator) fillTableReferences(meta *tableMeta) error {
 			if idx < 0 || int64(len(meta.Cols)) <= idx {
 				return fmt.Errorf("out of bounds foreign key field (to) at index %d", idx)
 			}
-			ref.PointsToFields = append(ref.PointsToFields, fieldNames{
-				PgName: meta.Cols[idx].PgName,
-				GoName: meta.Cols[idx].GoName,
-			})
+			ref.PointsToFields = append(ref.PointsToFields, &meta.Cols[idx])
 		}
 
-		// this call is what makes this routine run N+1 queries
-		fromFields, err := g.pointsFromColMeta(ref.PgPointsFrom)
-		if err != nil {
-			return err
-		}
+		ref.PointsTo = &g.tables[pgPointsTo].meta
+		ref.PointsFrom = &g.tables[pgPointsFrom].meta
+
+		fromCols := ref.PointsFrom.Cols
 
 		ref.OneToOne = true
 		for _, idx := range pointsFromIdxs {
 			idx--
 
-			if idx < 0 || int64(len(fromFields)) <= idx {
+			if idx < 0 || int64(len(fromCols)) <= idx {
 				return fmt.Errorf("out of bounds foreign key field (from) at index %d", idx)
 			}
 
-			ffield := &fromFields[idx]
-			ref.PointsFromFields = append(ref.PointsFromFields, ffield.name)
-			ref.OneToOne = ref.OneToOne && ffield.hasUniqueIndex
-			ref.Nullable = ffield.isNullable
+			fcol := &fromCols[idx]
+			ref.PointsFromFields = append(ref.PointsFromFields, fcol)
+			ref.OneToOne = ref.OneToOne && fcol.IsUnique
+			ref.Nullable = fcol.Nullable
 		}
 
 		meta.References = append(meta.References, ref)
 	}
 
 	return nil
-}
-
-type pointsFromColMeta struct {
-	name           fieldNames
-	hasUniqueIndex bool
-	isNullable     bool
-}
-
-// pointsFromMeta returns the names of a tables columns given the table name
-// in postgres
-func (g *Generator) pointsFromColMeta(table string) (
-	[]pointsFromColMeta,
-	error,
-) {
-	rows, err := g.db.Query(`
-		WITH unique_cols AS (
-			SELECT
-				UNNEST(ix.indkey) as colnum,
-				ix.indisunique as is_unique
-			FROM pg_class c
-			JOIN pg_index ix
-				ON (c.oid = ix.indrelid)
-			WHERE c.relname = $1
-		)
-
-		SELECT
-			a.attname,
-			COALESCE(u.is_unique, 'f'::bool),
-			a.attnotnull
-		FROM pg_attribute a
-		INNER JOIN pg_class c
-			ON (c.oid = a.attrelid)
-		LEFT JOIN unique_cols u
-			ON (u.colnum = a.attnum)
-		WHERE a.attisdropped = false
-		  AND a.attnum > 0
-		  AND c.relname = $1
-		`, table)
-	if err != nil {
-		return nil, err
-	}
-
-	cols := []pointsFromColMeta{}
-
-	for rows.Next() {
-		var col pointsFromColMeta
-		var notNull bool
-		err = rows.Scan(&col.name.PgName, &col.hasUniqueIndex, &notNull)
-		if err != nil {
-			return nil, err
-		}
-		col.isNullable = !notNull
-		col.name.GoName = pgToGoName(col.name.PgName)
-		cols = append(cols, col)
-	}
-
-	return cols, nil
 }
 
 // Given the oid of a postgres type, return all the variants that

--- a/include/include_test.go
+++ b/include/include_test.go
@@ -180,3 +180,34 @@ func TestParseErrors(t *testing.T) {
 		}
 	}
 }
+
+func TestCyclicIncludeSpec(t *testing.T) {
+	cyclic := Spec{
+		TableName: "foo",
+	}
+	cyclic.Includes = map[string]*Spec{
+		"bar": {
+			TableName: "bar",
+			Includes: map[string]*Spec{
+				"foo": &cyclic,
+			},
+		},
+	}
+
+	containsCyclic := Spec{
+		TableName: "baz",
+		Includes: map[string]*Spec{
+			"foo": &cyclic,
+		},
+	}
+
+	txt := cyclic.String()
+	if txt != "foo.bar.foo" {
+		t.Fatalf("bad txt: %s", txt)
+	}
+
+	txt = containsCyclic.String()
+	if txt != "baz.foo.bar.foo" {
+		t.Fatalf("bad txt: %s", txt)
+	}
+}


### PR DESCRIPTION
This patch adds some tests for cyclic object graphs and
fixes everything needed to make them pass. There are a bunch
of different fixes required in order to make this work. Some
highlights are:

  - We teach include specs to handle cycles while printing themselves.
  - Include specs how have a documented way to represent cycles.
  - We thread all of the rows ever loaded through our recursive include
    filling routines rather than just carrying the rows from the most
    recent generation over. This allows us to notice when a row has
    already been loaded and use the object already in memory rather than
    creating a new object with identical data but a different memory
    location.

After this patch the go object graph that pggen gen loads during include
filling faithfully represents the graph of database objects.

This is a breaking change because 1-* relationships were previously
represented with slices of model structs rather than slices of pointers
to model structs, which makes it impossible to faithfully represent
the object graph found in the database.

Closes #51