### PR TITLE
fix bug in enum scanning

### DIFF
--- a/cmd/pggen/test/tables_test.go
+++ b/cmd/pggen/test/tables_test.go
@@ -750,9 +750,12 @@ func TestEnumBlanks(t *testing.T) {
 	})
 	chkErr(t, err)
 
-	_, err = txClient.InsertEnumBlank(ctx, &db_shims.EnumBlank{
+	id, err := txClient.InsertEnumBlank(ctx, &db_shims.EnumBlank{
 		Value: db_shims.EnumTypeWithBlankBlank,
 	})
+	chkErr(t, err)
+
+	_, err = txClient.GetEnumBlank(ctx, id)
 	chkErr(t, err)
 
 	if db_shims.EnumTypeWithBlankBlank.String() != "blank" {

--- a/gen/gen_query.go
+++ b/gen/gen_query.go
@@ -105,7 +105,7 @@ func (r *{{ .ReturnTypeName }}) Scan(ctx context.Context, client *PGClient, rs *
 	err := rs.Scan(
 		{{- range .ReturnCols }}
 		{{- if .Nullable }}
-		{{ call .TypeInfo.SqlReceiver (printf "scan%s" .GoName) }},
+		{{ call .TypeInfo.NullSqlReceiver (printf "scan%s" .GoName) }},
 		{{- else }}
 		{{ call .TypeInfo.SqlReceiver (printf "r.%s" .GoName) }},
 		{{- end }}
@@ -191,7 +191,7 @@ func (p *pgClientImpl) {{ .ConfigData.Name }}(
 		{{- else }}
 		{{- if (index .ReturnCols 0).Nullable }}
 		var scanTgt {{ (index .ReturnCols 0).TypeInfo.ScanNullName }}
-		err = rows.Scan({{ call (index .ReturnCols 0).TypeInfo.SqlReceiver "scanTgt" }})
+		err = rows.Scan({{ call (index .ReturnCols 0).TypeInfo.NullSqlReceiver "scanTgt" }})
 		if err != nil {
 			return nil, err
 		}

--- a/gen/gen_table.go
+++ b/gen/gen_table.go
@@ -237,7 +237,7 @@ var scannerTabFor{{ .GoName }} = [...]func(*{{ .GoName }}, *nullableScanTgtsFor{
 		nullableTgts *nullableScanTgtsFor{{ $.GoName }},
 	) interface{} {
 		{{- if .Nullable }}
-		return {{ call .TypeInfo.SqlReceiver (printf "nullableTgts.scan%s" .GoName) }}
+		return {{ call .TypeInfo.NullSqlReceiver (printf "nullableTgts.scan%s" .GoName) }}
 		{{- else }}
 		return {{ call .TypeInfo.SqlReceiver (printf "r.%s" .GoName) }}
 		{{- end }}


### PR DESCRIPTION
This patch fixes a bug where `pggen` would error when trying to
scan NOT NULL enum types.

Closes #62