### PR TITLE
split gen pkg up into subpackages

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,5 +411,5 @@ writing model structs which match up with the database table definitions.
 
 `pggen` is configured with a `toml` file. Some of the configuration options have already
 been mentioned in this document, but the most complete source of documentation
-on is the comments in `gen/config_file.go`.
+on is the comments in `gen/internal/config/config.go`.
 An example file can be found at `pggen/test/pggen.toml`.

--- a/cmd/pggen/test/cli_test.go
+++ b/cmd/pggen/test/cli_test.go
@@ -350,8 +350,9 @@ func runCLITest(
 	cmdTxt := cmdTxtBuilder.String()
 
 	defer func() {
+		envTxt := strings.Join(test.extraEnv, " ")
 		if err != nil {
-			err = fmt.Errorf("CMD: %s\n%s", cmdTxt, err.Error())
+			err = fmt.Errorf("CMD: %s %s\n%s", envTxt, cmdTxt, err.Error())
 		}
 	}()
 

--- a/gen/gen_pgclient.go
+++ b/gen/gen_pgclient.go
@@ -3,9 +3,12 @@ package gen
 import (
 	"io"
 	"text/template"
+
+	"github.com/opendoor-labs/pggen/gen/internal/config"
+	"github.com/opendoor-labs/pggen/gen/internal/names"
 )
 
-func (g *Generator) genPGClient(into io.Writer, tables []tableConfig) error {
+func (g *Generator) genPGClient(into io.Writer, tables []config.TableConfig) error {
 	g.imports[`"github.com/opendoor-labs/pggen"`] = true
 	g.imports[`"database/sql"`] = true
 
@@ -13,12 +16,12 @@ func (g *Generator) genPGClient(into io.Writer, tables []tableConfig) error {
 		ModelNames []string
 	}
 
-	names := make([]string, 0, len(tables))
+	modelNames := make([]string, 0, len(tables))
 	for _, tc := range tables {
-		names = append(names, pgTableToGoModel(tc.Name))
+		modelNames = append(modelNames, names.PgTableToGoModel(tc.Name))
 	}
 
-	gCtx := genCtx{ModelNames: names}
+	gCtx := genCtx{ModelNames: modelNames}
 
 	return pgClientTmpl.Execute(into, &gCtx)
 }

--- a/gen/gen_prelude.go
+++ b/gen/gen_prelude.go
@@ -4,6 +4,8 @@ import (
 	"path/filepath"
 	"strings"
 	"text/template"
+
+	"github.com/opendoor-labs/pggen/gen/internal/utils"
 )
 
 func (g *Generator) genPrelude() error {
@@ -21,7 +23,7 @@ func (g *Generator) genPrelude() error {
 	}
 
 	preludeName := filepath.Join(filepath.Dir(g.config.OutputFileName), "pggen_prelude.gen.go")
-	return writeGoFile(preludeName, []byte(out.String()))
+	return utils.WriteGoFile(preludeName, []byte(out.String()))
 }
 
 var preludeTmpl *template.Template = template.Must(template.New("prelude-tmpl").Parse(`

--- a/gen/gen_stmt.go
+++ b/gen/gen_stmt.go
@@ -3,11 +3,14 @@ package gen
 import (
 	"io"
 	"text/template"
+
+	"github.com/opendoor-labs/pggen/gen/internal/config"
+	"github.com/opendoor-labs/pggen/gen/internal/names"
 )
 
-func (g *Generator) genStmts(into io.Writer, stmts []stmtConfig) error {
+func (g *Generator) genStmts(into io.Writer, stmts []config.StmtConfig) error {
 	if len(stmts) > 0 {
-		g.infof("	generating %d statements\n", len(stmts))
+		g.log.Infof("	generating %d statements\n", len(stmts))
 	} else {
 		return nil
 	}
@@ -25,12 +28,12 @@ func (g *Generator) genStmts(into io.Writer, stmts []stmtConfig) error {
 	return nil
 }
 
-func (g *Generator) genStmt(into io.Writer, stmt *stmtConfig) error {
-	g.infof("		generating statement '%s'\n", stmt.Name)
+func (g *Generator) genStmt(into io.Writer, stmt *config.StmtConfig) error {
+	g.log.Infof("		generating statement '%s'\n", stmt.Name)
 
-	stmt.Name = pgToGoName(stmt.Name)
+	stmt.Name = names.PgToGoName(stmt.Name)
 
-	meta, err := g.stmtMeta(stmt)
+	meta, err := g.metaResolver.StmtMeta(stmt)
 	if err != nil {
 		return err
 	}

--- a/gen/gen_stored_func.go
+++ b/gen/gen_stored_func.go
@@ -3,20 +3,22 @@ package gen
 import (
 	"strings"
 	"text/template"
+
+	"github.com/opendoor-labs/pggen/gen/internal/config"
 )
 
 func (g *Generator) genStoredFuncs(
 	into *strings.Builder,
-	funcs []storedFuncConfig,
+	funcs []config.StoredFuncConfig,
 ) error {
 	if len(funcs) == 0 {
 		return nil
 	}
 
-	g.infof("	generating %d stored functions\n", len(funcs))
+	g.log.Infof("	generating %d stored functions\n", len(funcs))
 
 	for _, storedFunc := range funcs {
-		args, err := g.funcArgs(storedFunc.Name)
+		args, err := g.metaResolver.FuncArgs(storedFunc.Name)
 		if err != nil {
 			return err
 		}
@@ -33,7 +35,7 @@ func (g *Generator) genStoredFuncs(
 		// generate a fake query config because stored procs are
 		// just a special case of queries where we can do a little
 		// bit better when it comes to naming arguments.
-		queryConf := queryConfig{
+		queryConf := config.QueryConfig{
 			Name:          storedFunc.Name,
 			Body:          queryTxt.String(),
 			NullFlags:     storedFunc.NullFlags,

--- a/gen/internal/log/log.go
+++ b/gen/internal/log/log.go
@@ -1,0 +1,41 @@
+// package log provides some simple information level print helpers wrapped
+// up in a lightweight struct that can be embedded in other objects
+package log
+
+import (
+	"fmt"
+	"os"
+)
+
+type Logger struct {
+	// The verbosity level of this logger. -1 means quiet mode,
+	// 0 (the default) means normal mode, and 1 means verbose mode.
+	level int
+}
+
+func NewLogger(level int) *Logger {
+	return &Logger{level: level}
+}
+
+// Print `output` at a normal verbosity level
+func (l *Logger) Info(output string) {
+	if l.level >= 0 {
+		fmt.Print(output)
+	}
+}
+
+// Print `output` at a normal verbosity level, formatting the output
+// using the standard formatting codes from `fmt`.
+func (l *Logger) Infof(format string, a ...interface{}) {
+	l.Info(fmt.Sprintf(format, a...))
+}
+
+func (l *Logger) Warn(output string) {
+	if l.level >= -1 {
+		fmt.Fprint(os.Stderr, output)
+	}
+}
+
+func (l *Logger) Warnf(format string, a ...interface{}) {
+	l.Warn(fmt.Sprintf("WARN: "+format, a...))
+}

--- a/gen/internal/meta/meta_test.go
+++ b/gen/internal/meta/meta_test.go
@@ -1,4 +1,4 @@
-package gen
+package meta
 
 import (
 	"reflect"

--- a/gen/internal/meta/table_meta.go
+++ b/gen/internal/meta/table_meta.go
@@ -1,0 +1,495 @@
+package meta
+
+import (
+	"database/sql"
+	"fmt"
+
+	"github.com/lib/pq"
+
+	"github.com/opendoor-labs/pggen/gen/internal/config"
+	"github.com/opendoor-labs/pggen/gen/internal/log"
+	"github.com/opendoor-labs/pggen/gen/internal/names"
+	"github.com/opendoor-labs/pggen/gen/internal/types"
+	"github.com/opendoor-labs/pggen/include"
+)
+
+// tablesMeta contains information _all_ of the tables that pggen is awair of
+type tablesMeta struct {
+	// A table mapping go type name for a table struct to the postgres
+	// name for that table.
+	tableTyNameToTableName map[string]string
+	// A mapping from the postgres table name to information about the table
+	tableInfo map[string]*TableGenInfo
+}
+
+type tableResolver struct {
+	meta         tablesMeta
+	db           *sql.DB
+	log          *log.Logger
+	typeResolver *types.Resolver
+}
+
+func newTableResolver(l *log.Logger, db *sql.DB, typeResolver *types.Resolver) *tableResolver {
+	return &tableResolver{
+		meta: tablesMeta{
+			tableTyNameToTableName: map[string]string{},
+			tableInfo:              map[string]*TableGenInfo{},
+		},
+		log:          l,
+		typeResolver: typeResolver,
+		db:           db,
+	}
+}
+
+// Information about a single table required for code generation.
+//
+// The reason there is both a *Meta and *GenInfo struct for tables
+// is that `tableMeta` is meant to be narrowly focused on metadata
+// that postgres provides us, while things in `TableGenInfo` are
+// more specific to `pggen`'s internal needs.
+type TableGenInfo struct {
+	Config *config.TableConfig
+	// Table relationships that have been explicitly configured
+	// rather than infered from the database schema itself.
+	ExplicitBelongsTo []RefMeta
+	// The include spec which represents the transitive closure of
+	// this tables family
+	AllIncludeSpec *include.Spec
+	// If true, this table does have an update timestamp field
+	HasUpdateAtField bool
+	// True if the update at field can be null
+	UpdatedAtFieldIsNullable bool
+	// True if the updated at field has a time zone
+	UpdatedAtHasTimezone bool
+	// If true, this table does have a create timestamp field
+	HasCreatedAtField bool
+	// True if the created at field can be null
+	CreatedAtFieldIsNullable bool
+	// True if the created at field has a time zone
+	CreatedAtHasTimezone bool
+	// The table metadata as postgres reports it
+	Meta tableMeta
+}
+
+// nullFlags computes the null flags specifying the nullness of this
+// table in the same format used by the `null_flags` config option
+func (info TableGenInfo) nullFlags() string {
+	nf := make([]byte, 0, len(info.Meta.Cols))
+	for _, c := range info.Meta.Cols {
+		if c.Nullable {
+			nf = append(nf, 'n')
+		} else {
+			nf = append(nf, '-')
+		}
+	}
+	return string(nf)
+}
+
+func (tr *tableResolver) populateTableInfo(tables []config.TableConfig) error {
+	tr.meta.tableInfo = map[string]*TableGenInfo{}
+	tr.meta.tableTyNameToTableName = map[string]string{}
+	for i, table := range tables {
+		info := &TableGenInfo{}
+		info.Config = &tables[i]
+
+		meta, err := tr.tableMeta(table.Name)
+		if err != nil {
+			return fmt.Errorf("table '%s': %s", table.Name, err.Error())
+		}
+		info.Meta = meta
+
+		tr.meta.tableInfo[table.Name] = info
+		tr.meta.tableTyNameToTableName[meta.GoName] = meta.PgName
+	}
+
+	// fill in all the reference we can automatically detect
+	for _, table := range tr.meta.tableInfo {
+		err := tr.fillTableReferences(&table.Meta)
+		if err != nil {
+			return err
+		}
+	}
+
+	err := tr.buildExplicitBelongsToMapping(tables, tr.meta.tableInfo)
+	if err != nil {
+		return err
+	}
+
+	// fill in all the allIncludeSpecs
+	for _, info := range tr.meta.tableInfo {
+		err := ensureSpec(tr.meta.tableInfo, info)
+		if err != nil {
+			return err
+		}
+	}
+
+	for _, info := range tr.meta.tableInfo {
+		tr.setTimestampFlags(info)
+	}
+
+	return nil
+}
+
+func (tr *tableResolver) setTimestampFlags(info *TableGenInfo) {
+	if len(info.Config.CreatedAtField) > 0 {
+		for _, cm := range info.Meta.Cols {
+			if cm.PgName == info.Config.CreatedAtField {
+				info.HasCreatedAtField = true
+				info.CreatedAtFieldIsNullable = cm.Nullable
+				info.CreatedAtHasTimezone = cm.TypeInfo.IsTimestampWithZone
+				break
+			}
+		}
+
+		if !info.HasCreatedAtField {
+			tr.log.Warnf(
+				"table '%s' has no '%s' created at timestamp\n",
+				info.Config.Name,
+				info.Config.CreatedAtField,
+			)
+		}
+	}
+
+	if len(info.Config.UpdatedAtField) > 0 {
+		for _, cm := range info.Meta.Cols {
+			if cm.PgName == info.Config.UpdatedAtField {
+				info.HasUpdateAtField = true
+				info.UpdatedAtFieldIsNullable = cm.Nullable
+				info.UpdatedAtHasTimezone = cm.TypeInfo.IsTimestampWithZone
+				break
+			}
+		}
+
+		if !info.HasUpdateAtField {
+			tr.log.Warnf(
+				"table '%s' has no '%s' updated at timestamp\n",
+				info.Config.Name,
+				info.Config.UpdatedAtField,
+			)
+		}
+	}
+}
+
+func ensureSpec(tables map[string]*TableGenInfo, info *TableGenInfo) error {
+	if info.AllIncludeSpec != nil {
+		// Some other `ensureSpec` already filled this in for us. Great!
+		return nil
+	}
+
+	info.AllIncludeSpec = &include.Spec{
+		TableName: info.Meta.PgName,
+		Includes:  map[string]*include.Spec{},
+	}
+
+	ensureReferencedSpec := func(ref *RefMeta) error {
+		subInfo := tables[ref.PointsFrom.PgName]
+		if subInfo == nil {
+			// This table is referenced in the database schema but not in the
+			// config file.
+			return nil
+		}
+
+		err := ensureSpec(tables, subInfo)
+		if err != nil {
+			return err
+		}
+		subSpec := subInfo.AllIncludeSpec
+		info.AllIncludeSpec.Includes[subSpec.TableName] = subSpec
+
+		return nil
+	}
+
+	for _, ref := range info.Meta.References {
+		err := ensureReferencedSpec(&ref)
+		if err != nil {
+			return err
+		}
+	}
+	for _, ref := range info.ExplicitBelongsTo {
+		err := ensureReferencedSpec(&ref)
+		if err != nil {
+			return err
+		}
+	}
+
+	if len(info.AllIncludeSpec.Includes) == 0 {
+		info.AllIncludeSpec.Includes = nil
+	}
+
+	return nil
+}
+
+func (tr *tableResolver) buildExplicitBelongsToMapping(
+	tables []config.TableConfig,
+	infoTab map[string]*TableGenInfo,
+) error {
+	for _, table := range tables {
+		pointsFromTable := tr.meta.tableInfo[table.Name]
+
+		for _, belongsTo := range table.BelongsTo {
+			if len(belongsTo.Table) == 0 {
+				return fmt.Errorf(
+					"%s: belongs_to requires 'name' key",
+					table.Name,
+				)
+			}
+
+			if len(belongsTo.KeyField) == 0 {
+				return fmt.Errorf(
+					"%s: belongs_to requires 'key_field' key",
+					table.Name,
+				)
+			}
+
+			var belongsToColMeta *ColMeta
+			for i, col := range pointsFromTable.Meta.Cols {
+				if col.PgName == belongsTo.KeyField {
+					belongsToColMeta = &pointsFromTable.Meta.Cols[i]
+				}
+			}
+			if belongsToColMeta == nil {
+				return fmt.Errorf(
+					"table '%s' has no field '%s'",
+					table.Name,
+					belongsTo.KeyField,
+				)
+			}
+
+			pointsToMeta := infoTab[belongsTo.Table].Meta
+			ref := RefMeta{
+				PointsTo:         &tr.meta.tableInfo[belongsTo.Table].Meta,
+				PointsToFields:   []*ColMeta{pointsToMeta.PkeyCol},
+				PointsFrom:       &tr.meta.tableInfo[table.Name].Meta,
+				PointsFromFields: []*ColMeta{belongsToColMeta},
+				OneToOne:         belongsTo.OneToOne,
+				Nullable:         belongsToColMeta.Nullable,
+			}
+
+			info := infoTab[belongsTo.Table]
+			info.ExplicitBelongsTo = append(info.ExplicitBelongsTo, ref)
+			infoTab[belongsTo.Table] = info
+		}
+	}
+
+	return nil
+}
+
+//
+// queries
+//
+
+// tableMeta contains metadata about a postgres table
+type tableMeta struct {
+	PgName       string
+	GoName       string
+	PluralGoName string
+	// metadata for the primary key column
+	PkeyCol *ColMeta
+	// Metadata about the tables columns
+	Cols []ColMeta
+	// A list of the postgres names of tables which reference this one
+	References []RefMeta
+	// If true, this table does have an update timestamp field
+	HasUpdateAtField bool
+	// If true, this table does have a create timestamp field
+	HasCreatedAtField bool
+	// The 0-based index of the primary key column
+	PkeyColIdx int
+}
+
+// colMeta contains metadata about postgres table columns such column
+// names, types, nullability, default...
+type ColMeta struct {
+	// postgres's internal column number for this column
+	ColNum int32
+	// the name of the field in the go struct which corresponds to this column
+	GoName string
+	// the name of this column in postgres
+	PgName string
+	// name of the type of this column
+	PgType string
+	// a more descriptive record of the type of this column
+	TypeInfo types.Info
+	// true if this column can be null
+	Nullable bool
+	// the postgres default value for this column
+	DefaultExpr string
+	// true if this column is the primary key for this table
+	IsPrimary bool
+	// true if this column has a UNIQUE index on it
+	IsUnique bool
+}
+
+// Given the name of a table returns metadata about it
+func (tr *tableResolver) tableMeta(table string) (tableMeta, error) {
+	rows, err := tr.db.Query(`
+		WITH unique_cols AS (
+			SELECT
+				UNNEST(ix.indkey) as colnum,
+				ix.indisunique as is_unique
+			FROM pg_class c
+			JOIN pg_index ix
+				ON (c.oid = ix.indrelid)
+			WHERE c.relname = $1
+		)
+
+		SELECT DISTINCT ON (a.attnum)
+			a.attnum AS col_num,
+			a.attname AS col_name,
+			format_type(a.atttypid, a.atttypmod) AS col_type,
+			NOT a.attnotnull AS nullable,
+			COALESCE(pg_get_expr(ad.adbin, ad.adrelid), '') AS default_expr,
+			COALESCE(ct.contype = 'p', false) AS is_primary,
+			COALESCE(u.is_unique, 'f'::bool) AS is_unique
+		FROM pg_attribute a
+		INNER JOIN pg_class c
+			ON (c.oid = a.attrelid)
+		LEFT JOIN pg_constraint ct
+			ON (ct.conrelid = c.oid AND a.attnum = ANY(ct.conkey) AND ct.contype = 'p')
+		LEFT JOIN pg_attrdef ad
+			ON (ad.adrelid = c.oid AND ad.adnum = a.attnum)
+		LEFT JOIN unique_cols u
+			ON (u.colnum = a.attnum)
+		WHERE a.attisdropped = false AND c.relname = $1 AND (a.attnum > 0)
+		ORDER BY a.attnum
+		`, table)
+	if err != nil {
+		return tableMeta{}, err
+	}
+
+	var cols []ColMeta
+	for rows.Next() {
+		var col ColMeta
+		err = rows.Scan(
+			&col.ColNum,
+			&col.PgName,
+			&col.PgType,
+			&col.Nullable,
+			&col.DefaultExpr,
+			&col.IsPrimary,
+			&col.IsUnique,
+		)
+		if err != nil {
+			return tableMeta{}, err
+		}
+		typeInfo, err := tr.typeResolver.TypeInfoOf(col.PgType)
+		if err != nil {
+			return tableMeta{}, fmt.Errorf("column '%s': %s", col.PgName, err.Error())
+		}
+		col.TypeInfo = *typeInfo
+		col.GoName = names.PgToGoName(col.PgName)
+		cols = append(cols, col)
+	}
+	if len(cols) == 0 {
+		return tableMeta{}, fmt.Errorf(
+			"could not find table '%s' in the database",
+			table,
+		)
+	}
+
+	var (
+		pkeyCol    *ColMeta
+		pkeyColIdx int
+	)
+	for i, c := range cols {
+		if c.IsPrimary {
+			if pkeyCol != nil {
+				return tableMeta{}, fmt.Errorf("tables with multiple primary keys not supported")
+			}
+
+			pkeyCol = &cols[i]
+			pkeyColIdx = i
+		}
+	}
+
+	return tableMeta{
+		PgName:       table,
+		GoName:       names.PgTableToGoModel(table),
+		PluralGoName: names.PgToGoName(table),
+		PkeyCol:      pkeyCol,
+		PkeyColIdx:   pkeyColIdx,
+		Cols:         cols,
+	}, nil
+}
+
+// Given a tableMeta with the PgName and Cols already filled out, fill in the
+// References list. Any tables which are referenced by the given table must
+// already be loaded into `g.tables`.
+func (tr *tableResolver) fillTableReferences(meta *tableMeta) error {
+	rows, err := tr.db.Query(`
+		SELECT
+			pt.relname as points_to,
+			c.confkey as points_to_keys,
+			pf.relname as points_from,
+			c.conkey as points_from_keys
+		FROM pg_constraint c
+		JOIN pg_class pt
+			ON (pt.oid = c.confrelid)
+		JOIN pg_class pf
+			ON (c.conrelid = pf.oid)
+		WHERE c.contype = 'f'
+		  AND pt.relname = $1
+		`, meta.PgName)
+	if err != nil {
+		return err
+	}
+
+	metaColNumToIdx := columnResolverTable(meta.Cols)
+
+	for rows.Next() {
+
+		var (
+			pgPointsTo   string
+			pgPointsFrom string
+		)
+
+		pointsToIdxs := []int64{}
+		pointsFromIdxs := []int64{}
+		var ref RefMeta
+		err = rows.Scan(
+			&pgPointsTo, pq.Array(&pointsToIdxs),
+			&pgPointsFrom, pq.Array(&pointsFromIdxs),
+		)
+		if err != nil {
+			return err
+		}
+
+		_, inTOMLConfig := tr.meta.tableInfo[pgPointsFrom]
+		if !inTOMLConfig {
+			continue
+		}
+
+		for _, idx := range pointsToIdxs {
+			// convert the ColNum to an index into the Cols array
+			if idx < 0 || int64(len(metaColNumToIdx)) <= idx {
+				return fmt.Errorf("out of bounds foreign key field (to) at index %d", idx)
+			}
+			idx = int64(metaColNumToIdx[idx])
+
+			ref.PointsToFields = append(ref.PointsToFields, &meta.Cols[idx])
+		}
+
+		ref.PointsTo = &tr.meta.tableInfo[pgPointsTo].Meta
+		ref.PointsFrom = &tr.meta.tableInfo[pgPointsFrom].Meta
+
+		fromCols := ref.PointsFrom.Cols
+		fromColsColNumToIdx := columnResolverTable(fromCols)
+
+		ref.OneToOne = true
+		for _, idx := range pointsFromIdxs {
+			if idx < 0 || int64(len(fromColsColNumToIdx)) <= idx {
+				return fmt.Errorf("out of bounds foreign key field (from) at index %d", idx)
+			}
+			idx = int64(fromColsColNumToIdx[idx])
+
+			fcol := &fromCols[idx]
+			ref.PointsFromFields = append(ref.PointsFromFields, fcol)
+			ref.OneToOne = ref.OneToOne && fcol.IsUnique
+			ref.Nullable = fcol.Nullable
+		}
+
+		meta.References = append(meta.References, ref)
+	}
+
+	return nil
+}

--- a/gen/internal/names/names.go
+++ b/gen/internal/names/names.go
@@ -1,4 +1,4 @@
-package gen
+package names
 
 import (
 	"strings"
@@ -14,13 +14,13 @@ import (
 // with a given stored function or prepared statement.
 //
 
-func pgTableToGoModel(tableName string) string {
-	return pgToGoName(inflection.Singular(tableName))
+func PgTableToGoModel(tableName string) string {
+	return PgToGoName(inflection.Singular(tableName))
 }
 
 // Convert a postgres name (assumed to be snake_case)
 // to a PascalCaseName
-func pgToGoName(snakeName string) string {
+func PgToGoName(snakeName string) string {
 	needsUpper := true
 
 	var res strings.Builder

--- a/gen/internal/names/names_test.go
+++ b/gen/internal/names/names_test.go
@@ -1,4 +1,4 @@
-package gen
+package names
 
 import (
 	"testing"
@@ -34,7 +34,7 @@ func TestPgToGoName(t *testing.T) {
 	}
 
 	for i, c := range cases {
-		actual := pgToGoName(c.src)
+		actual := PgToGoName(c.src)
 		if actual != c.expected {
 			t.Fatalf("case %d: expected '%s', got '%s'", i, c.expected, actual)
 		}

--- a/gen/internal/types/parse.go
+++ b/gen/internal/types/parse.go
@@ -1,4 +1,4 @@
-package gen
+package types
 
 import (
 	"fmt"

--- a/gen/internal/types/parse_test.go
+++ b/gen/internal/types/parse_test.go
@@ -1,4 +1,4 @@
-package gen
+package types
 
 import (
 	"regexp"

--- a/gen/internal/types/type_set.go
+++ b/gen/internal/types/type_set.go
@@ -1,11 +1,13 @@
-package gen
+package types
 
 import (
 	"fmt"
 	"io"
+
+	"github.com/opendoor-labs/pggen/gen/internal/utils"
 )
 
-// typeSet is a set of types that pggen wants to emit. Each type
+// set is a set of types that pggen wants to emit. Each type
 // in the set consists of a 3-tuple of (<type name>, <type sig>, <type body>).
 // Identity is determined by the tuple of (<type name>, <type sig>), and
 // <type body> contains the actual definition of the type that will be emitted.
@@ -14,7 +16,7 @@ import (
 // types are good enough to count as the same thing. In particular, tables with child
 // entities have some extra slices attached to them for the child entities, but we still
 // want people to be able to return the table's generated type from custom queries.
-type typeSet struct {
+type set struct {
 	// A set mapping return type names to type definitions and signatures.
 	set map[string]typeDecl
 }
@@ -26,8 +28,8 @@ type typeDecl struct {
 	body string
 }
 
-func newTypeSet() typeSet {
-	return typeSet{
+func newSet() set {
+	return set{
 		set: map[string]typeDecl{},
 	}
 }
@@ -35,12 +37,12 @@ func newTypeSet() typeSet {
 // Probe the type set for a specific type defintion. Can allow us to skip
 // some work for types generated purely off of database objects such as
 // user-defined postgres types.
-func (t *typeSet) probe(name string) bool {
+func (t *set) probe(name string) bool {
 	_, inSet := t.set[name]
 	return inSet
 }
 
-func (t *typeSet) emitType(name string, sig string, body string) error {
+func (t *set) emitType(name string, sig string, body string) error {
 	existingDecl, inSet := t.set[name]
 	if inSet {
 		if existingDecl.sig != sig {
@@ -65,9 +67,9 @@ but another has a return type with fields
 	return nil
 }
 
-func (t *typeSet) gen(into io.Writer) error {
+func (t *set) gen(into io.Writer) error {
 	for _, decl := range t.set {
-		err := writeCompletely(into, []byte(decl.body))
+		err := utils.WriteCompletely(into, []byte(decl.body))
 		if err != nil {
 			return err
 		}

--- a/gen/internal/utils/utils.go
+++ b/gen/internal/utils/utils.go
@@ -1,4 +1,4 @@
-package gen
+package utils
 
 import (
 	"fmt"
@@ -11,7 +11,7 @@ import (
 	"unicode"
 )
 
-func writeGoFile(path string, src []byte) error {
+func WriteGoFile(path string, src []byte) error {
 	outFile, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
 	if err != nil {
 		return err
@@ -23,10 +23,10 @@ func writeGoFile(path string, src []byte) error {
 		return fmt.Errorf("internal pggen error: %s", err.Error())
 	}
 
-	return writeCompletely(outFile, formattedSrc)
+	return WriteCompletely(outFile, formattedSrc)
 }
 
-func writeCompletely(w io.Writer, data []byte) error {
+func WriteCompletely(w io.Writer, data []byte) error {
 	for len(data) > 0 {
 		nbytes, err := w.Write(data)
 		if err != nil {
@@ -38,7 +38,7 @@ func writeCompletely(w io.Writer, data []byte) error {
 }
 
 // dirOf returns the name of the directory that `path` is contained by
-func dirOf(path string) (string, error) {
+func DirOf(path string) (string, error) {
 	abs, err := filepath.Abs(path)
 	if err != nil {
 		return "", err
@@ -47,13 +47,13 @@ func dirOf(path string) (string, error) {
 	return filepath.Base(filepath.Dir(abs)), nil
 }
 
-func randomName(base string) string {
+func RandomName(base string) string {
 	return fmt.Sprintf("%s_%d", base, rand.Int63())
 }
 
 // nullOutArgs takes a string containing an SQL query and replaces
 // all strings which match the regex `\$[0-9]+` outside of quotes.
-func nullOutArgs(query string) string {
+func NullOutArgs(query string) string {
 	lastChunkEnd := 0
 	chunks := []string{}
 	quoteRune := 'X'

--- a/gen/internal/utils/utils_test.go
+++ b/gen/internal/utils/utils_test.go
@@ -1,4 +1,4 @@
-package gen
+package utils
 
 import (
 	"testing"
@@ -53,7 +53,7 @@ func TestNullOutArgs(t *testing.T) {
 	}
 
 	for _, v := range vecs {
-		actual := nullOutArgs(v.input)
+		actual := NullOutArgs(v.input)
 		if actual != v.expected {
 			t.Errorf("\nExpected: %s\nActual: %s\n", v.expected, actual)
 		}


### PR DESCRIPTION
The gen package and the `Generator` struct were getting pretty
big and unweildy. This patch contains a major refactoring to
split much of the code out into a new tree of `internal` packages.

This goes quite a bit further than I originally envisioned when I
wrote #50, but once I got into it I realized that the code was pretty
tied together so splitting the table resolution out into its own package
would require splitting a bunch of things out into their own packages.

Closes #50