### PR TITLE
teach pggen to allow inserting primary keys

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -79,8 +79,8 @@ routine in `gen/utils.go` to skip the formatting and just dump the code to disk.
 ```
 diff --git a/gen/utils.go b/gen/utils.go
 index dd7804d..e3a446f 100644
---- a/gen/utils.go
-+++ b/gen/utils.go
+--- a/gen/internal/utils/utils.go
++++ b/gen/internal/utils/utils.go
 @@ -20,8 +20,9 @@ func writeGoFile(path string, src []byte) error {
 
  	formattedSrc, err := format.Source(src)

--- a/cmd/pggen/test/db.sql
+++ b/cmd/pggen/test/db.sql
@@ -284,6 +284,12 @@ CREATE TABLE will_get_new_column (
     f1 text NOT NULL
 );
 
+-- to test inserting when the primary key cannot be automatically computed by the database
+CREATE TABLE non_default_pkey (
+    id text PRIMARY KEY,
+    val integer
+);
+
 --
 -- Load Data
 --

--- a/cmd/pggen/test/pggen.toml
+++ b/cmd/pggen/test/pggen.toml
@@ -340,3 +340,6 @@
 
 [[table]]
     name = "will_get_new_column"
+
+[[table]]
+    name = "non_default_pkey"

--- a/cmd/pggen/test/tables_test.go
+++ b/cmd/pggen/test/tables_test.go
@@ -940,3 +940,18 @@ func TestNewColumn(t *testing.T) {
 		t.Fatalf("expected foo")
 	}
 }
+
+func TestInsertPkey(t *testing.T) {
+	txClient, err := pgClient.BeginTx(ctx, nil)
+	chkErr(t, err)
+	defer func() {
+		_ = txClient.Rollback()
+	}()
+
+	one := int64(1)
+	_, err = txClient.InsertNonDefaultPkey(ctx, &db_shims.NonDefaultPkey{
+		Id:  "foo",
+		Val: &one,
+	}, pggen.UsePkey)
+	chkErr(t, err)
+}

--- a/db_handle.go
+++ b/db_handle.go
@@ -1,0 +1,22 @@
+package pggen
+
+// db_handle.go defines the common interface shared by *sql.Tx and *sql.DB
+
+import (
+	"context"
+	"database/sql"
+)
+
+// DBHandle is an interface which contains the methods common to
+// *sql.Tx and *sql.DB, allowing for code to be generic over whether
+// or no the user is operating in a transaction
+type DBHandle interface {
+	Exec(query string, args ...interface{}) (sql.Result, error)
+	ExecContext(ctx context.Context, query string, args ...interface{}) (sql.Result, error)
+	Prepare(query string) (*sql.Stmt, error)
+	PrepareContext(ctx context.Context, query string) (*sql.Stmt, error)
+	Query(query string, args ...interface{}) (*sql.Rows, error)
+	QueryContext(ctx context.Context, query string, args ...interface{}) (*sql.Rows, error)
+	QueryRow(query string, args ...interface{}) *sql.Row
+	QueryRowContext(ctx context.Context, query string, args ...interface{}) *sql.Row
+}

--- a/field_set.go
+++ b/field_set.go
@@ -1,25 +1,10 @@
 package pggen
 
-import (
-	"context"
-	"database/sql"
+// field_set.go defines a bitset used for specifying subsets of fields
 
+import (
 	"github.com/willf/bitset"
 )
-
-// DBHandle is an interface which contains the methods common to
-// *sql.Tx and *sql.DB, allowing for code to be generic over whether
-// or no the user is operating in a transaction
-type DBHandle interface {
-	Exec(query string, args ...interface{}) (sql.Result, error)
-	ExecContext(ctx context.Context, query string, args ...interface{}) (sql.Result, error)
-	Prepare(query string) (*sql.Stmt, error)
-	PrepareContext(ctx context.Context, query string) (*sql.Stmt, error)
-	Query(query string, args ...interface{}) (*sql.Rows, error)
-	QueryContext(ctx context.Context, query string, args ...interface{}) (*sql.Rows, error)
-	QueryRow(query string, args ...interface{}) *sql.Row
-	QueryRowContext(ctx context.Context, query string, args ...interface{}) *sql.Row
-}
 
 // A bitset to use to select a subset of fields to update when calling
 // a generated Update<Entity> method. FieldSets are reference types like

--- a/gen/gen_prelude.go
+++ b/gen/gen_prelude.go
@@ -48,10 +48,11 @@ func genBulkInsertStmt(
 	fields []string,
 	nrecords int,
 	pkeyName string,
+	includeID bool,
 ) string {
 	var ret strings.Builder
 
-	genInsertCommon(&ret, table, fields, nrecords, pkeyName, true)
+	genInsertCommon(&ret, table, fields, nrecords, pkeyName, includeID)
 
 	ret.WriteString(" RETURNING \"")
 	ret.WriteString(pkeyName)

--- a/options.go
+++ b/options.go
@@ -1,0 +1,15 @@
+package pggen
+
+// options.go contains functional options that can be passed to generated code.
+
+type InsertOpt func(opts *InsertOptions)
+type InsertOptions struct {
+	UsePkey bool
+}
+
+// UsePkey tells an insert method to insert the primary key into the database
+// rather than let the database compute it automatically from the default value
+// as is the default.
+func UsePkey(opts *InsertOptions) {
+	opts.UsePkey = true
+}


### PR DESCRIPTION
This patch teaches the insert methods for pggen about a
new functional option that allows the user to ask `insert`
to include the primary key in the record inserted into
the database rather than taking the default value.

Closes #35