### PR TITLE
add support for custom names in `belongs_to`

### DIFF
--- a/cmd/pggen/test/db.sql
+++ b/cmd/pggen/test/db.sql
@@ -290,6 +290,17 @@ CREATE TABLE non_default_pkey (
     val integer
 );
 
+CREATE TABLE alternative_reference_name (
+    id SERIAL PRIMARY KEY NOT NULL,
+    small_entity_id integer NOT NULL
+        REFERENCES small_entities(id) ON DELETE RESTRICT ON UPDATE CASCADE
+);
+CREATE TABLE alternative_reference_name_1to1 (
+    id SERIAL PRIMARY KEY NOT NULL,
+    small_entity_id integer NOT NULL
+        REFERENCES small_entities(id) ON DELETE RESTRICT ON UPDATE CASCADE
+);
+
 --
 -- Load Data
 --

--- a/cmd/pggen/test/empty_models/generate.go
+++ b/cmd/pggen/test/empty_models/generate.go
@@ -1,4 +1,3 @@
 package empty_models
 
 //go:generate go run ../../main.go -o empty.gen.go pggen.toml
-

--- a/cmd/pggen/test/models/pggen.toml
+++ b/cmd/pggen/test/models/pggen.toml
@@ -343,3 +343,18 @@
 
 [[table]]
     name = "non_default_pkey"
+
+[[table]]
+    name = "alternative_reference_name"
+    [[table.belongs_to]]
+        table = "small_entities"
+        key_field = "small_entity_id"
+        parent_field_name = "CustomReferenceName"
+
+[[table]]
+    name = "alternative_reference_name_1to1"
+    [[table.belongs_to]]
+        table = "small_entities"
+        key_field = "small_entity_id"
+        one_to_one = true
+        parent_field_name = "Custom1to1ReferenceName"

--- a/cmd/pggen/test/tables_test.go
+++ b/cmd/pggen/test/tables_test.go
@@ -955,3 +955,15 @@ func TestInsertPkey(t *testing.T) {
 	}, pggen.UsePkey)
 	chkErr(t, err)
 }
+
+func TestCustomReferenceNames(t *testing.T) {
+	smallEntityType := reflect.TypeOf(models.SmallEntity{})
+
+	names := []string{"CustomReferenceName", "Custom1to1ReferenceName"}
+	for _, n := range names {
+		_, has := smallEntityType.FieldByName(n)
+		if !has {
+			t.Fatalf("pggen failed to generate '%s'", n)
+		}
+	}
+}

--- a/cmd/pggen/test/timestamps_test.go
+++ b/cmd/pggen/test/timestamps_test.go
@@ -6,8 +6,8 @@ import (
 	"time"
 
 	"github.com/opendoor-labs/pggen"
-	"github.com/opendoor-labs/pggen/cmd/pggen/test/models"
 	"github.com/opendoor-labs/pggen/cmd/pggen/test/global_ts_models"
+	"github.com/opendoor-labs/pggen/cmd/pggen/test/models"
 )
 
 func TestTimestampsBoth(t *testing.T) {

--- a/gen/gen_table.go
+++ b/gen/gen_table.go
@@ -182,9 +182,9 @@ type {{ .GoName }} struct {
 	{{- end }}
 	{{- range .References }}
 	{{- if .OneToOne }}
-	{{ .PointsFrom.GoName }} *{{ .PointsFrom.GoName }}
+	{{ .PointsFromFieldName }} *{{ .PointsFrom.GoName }}
 	{{- else }}
-	{{ .PointsFrom.PluralGoName }} []*{{ .PointsFrom.GoName }}
+	{{ .PointsFromFieldName }} []*{{ .PointsFrom.GoName }}
 	{{- end }}
 	{{- end }}
 }
@@ -953,7 +953,7 @@ func (p *pgClientImpl) impl{{ .GoName }}BulkFillIncludes(
 	// Fill in the {{ .PointsFrom.PluralGoName }} if it is in includes
 	subSpec, inIncludeSet = includes.Includes[` + "`" + `{{ .PointsFrom.PgName }}` + "`" + `]
 	if inIncludeSet {
-		err = p.private{{ $.GoName }}Fill{{ .PointsFrom.GoName }}(ctx, loadedRecordTab)
+		err = p.private{{ $.GoName }}Fill{{ .PointsFromFieldName }}(ctx, loadedRecordTab)
 		if err != nil {
 			return
 		}
@@ -962,16 +962,16 @@ func (p *pgClientImpl) impl{{ .GoName }}BulkFillIncludes(
 		for _, outer := range recs {
 			{{- if .OneToOne }}
 			if outer.{{ .PointsFrom.GoName }} != nil {
-				subRecs = append(subRecs, outer.{{ .PointsFrom.GoName }})
+				subRecs = append(subRecs, outer.{{ .PointsFromFieldName }})
 			}
 			{{- else }}
 			for i := range outer.{{ .PointsFrom.PluralGoName }} {
 				{{- if .Nullable }}
-				if outer.{{ .PointsFrom.PluralGoName }}[i] == nil {
+				if outer.{{ .PointsFromFieldName }}[i] == nil {
 					continue
 				}
 				{{- end }}
-				subRecs = append(subRecs, outer.{{ .PointsFrom.PluralGoName }}[i])
+				subRecs = append(subRecs, outer.{{ .PointsFromFieldName }}[i])
 			}
 			{{- end }}
 		}
@@ -990,7 +990,7 @@ func (p *pgClientImpl) impl{{ .GoName }}BulkFillIncludes(
 
 // For a give set of {{ $.GoName }}, fill in all the {{ .PointsFrom.GoName }}
 // connected to them using a single query.
-func (p *pgClientImpl) private{{ $.GoName }}Fill{{ .PointsFrom.GoName }}(
+func (p *pgClientImpl) private{{ $.GoName }}Fill{{ .PointsFromFieldName }}(
 	ctx context.Context,
 	loadedRecordTab map[string]interface{},
 ) error {
@@ -1055,10 +1055,10 @@ func (p *pgClientImpl) private{{ $.GoName }}Fill{{ .PointsFrom.GoName }}(
 		{{- end }}
 
 		{{- if .OneToOne }}
-		parentRec.{{ .PointsFrom.GoName }} = childRec
+		parentRec.{{ .PointsFromFieldName }} = childRec
 		break
 		{{- else }}
-		parentRec.{{ .PointsFrom.PluralGoName }} = append(parentRec.{{ .PointsFrom.PluralGoName }}, childRec)
+		parentRec.{{ .PointsFromFieldName }} = append(parentRec.{{ .PointsFrom.PluralGoName }}, childRec)
 		{{- end }}
 	}
 

--- a/gen/internal/config/config.go
+++ b/gen/internal/config/config.go
@@ -102,6 +102,9 @@ type BelongsTo struct {
 	KeyField string `toml:"key_field"`
 	// If true the owning table has at most one of this table
 	OneToOne bool `toml:"one_to_one"`
+	// Optional. The name to give the pointer field in the generated parent
+	// struct. If not provided, this will just be the name of the child struct.
+	ParentFieldName string `toml:"parent_field_name"`
 }
 
 type TypeOverride struct {

--- a/gen/internal/meta/meta.go
+++ b/gen/internal/meta/meta.go
@@ -466,6 +466,9 @@ type RefMeta struct {
 	// The names of the fields that are being used to refer to the key fields
 	// for the referenced table. Order matters.
 	PointsFromFields []*ColMeta
+	// The name of the field that should be generated in the model being pointed
+	// to by the foreign key (parent model).
+	PointsFromFieldName string
 	// Indicates that there can be at most one of these references between
 	// the two tables.
 	OneToOne bool


### PR DESCRIPTION
This patch teaches `pggen` to accept a new configuration option
when declaring a relationship between to tables. The new
`parent_field_name` option controls the name of the field which
is added to the generated model struct which corrisponds to the
table that is refered to by the foreign key in the database.

Closes #59