### PR TITLE
fix bug in include specs for named relationships

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.test
+main

--- a/cmd/pggen/test/models/pggen.toml
+++ b/cmd/pggen/test/models/pggen.toml
@@ -349,7 +349,7 @@
     [[table.belongs_to]]
         table = "small_entities"
         key_field = "small_entity_id"
-        parent_field_name = "CustomReferenceName"
+        parent_field_name = "custom_reference_name"
 
 [[table]]
     name = "alternative_reference_name_1to1"
@@ -357,4 +357,4 @@
         table = "small_entities"
         key_field = "small_entity_id"
         one_to_one = true
-        parent_field_name = "Custom1to1ReferenceName"
+        parent_field_name = "custom_1to1_reference_name"

--- a/gen/internal/meta/meta.go
+++ b/gen/internal/meta/meta.go
@@ -468,7 +468,9 @@ type RefMeta struct {
 	PointsFromFields []*ColMeta
 	// The name of the field that should be generated in the model being pointed
 	// to by the foreign key (parent model).
-	PointsFromFieldName string
+	GoPointsFromFieldName string
+	// A snake_case version of GoPointsFromFieldName
+	PgPointsFromFieldName string
 	// Indicates that there can be at most one of these references between
 	// the two tables.
 	OneToOne bool

--- a/include/include_test.go
+++ b/include/include_test.go
@@ -70,6 +70,24 @@ func TestParseSuccess(t *testing.T) {
 			src:    "  foos.{bars .blip. flip.dip ,bim.{a, b   ,c.{d   ,    e}}}    ",
 			result: "foos.{bars.blip.flip.dip,bim.{a,b,c.{d,e}}}",
 		},
+		{
+			// basic rename expression
+			src: `f.a->b`,
+		},
+		{
+			// normalize rename expressions
+			src:    "f.a->a",
+			result: "f.a",
+		},
+		{
+			// longer names and spaces
+			src:    " f . longer -> names_can_be_renamed_as_well ",
+			result: "f.longer->names_can_be_renamed_as_well",
+		},
+		{
+			// rename expression w/subspec
+			src: "f.n1->n2.baz",
+		},
 		// funny names
 		{
 			src: "f$",
@@ -158,6 +176,10 @@ func TestParseErrors(t *testing.T) {
 		{
 			src: `"blah balhjl`,
 			re:  "unexpected end of input in quoted identifier",
+		},
+		{
+			src: `top_level->rename.bad`,
+			re:  "unexpected extra token begining with '-'",
 		},
 	}
 


### PR DESCRIPTION
This patch fixes the way that pggen handles includes
when a child is given an explicitly configured name rather
than just using the name it infers from the name of the child
table.

Fixes #73