### PR TITLE
add ability to add custom tags to generated fields

### DIFF
--- a/cmd/pggen/test/db.sql
+++ b/cmd/pggen/test/db.sql
@@ -301,6 +301,11 @@ CREATE TABLE alternative_reference_name_1to1 (
         REFERENCES small_entities(id) ON DELETE RESTRICT ON UPDATE CASCADE
 );
 
+CREATE TABLE custom_default_uuids (
+    id SERIAL PRIMARY KEY NOT NULL,
+    uuid uuid NOT NULL DEFAULT uuid_generate_v4()
+);
+
 --
 -- Load Data
 --

--- a/cmd/pggen/test/gorm_compat_test.go
+++ b/cmd/pggen/test/gorm_compat_test.go
@@ -2,6 +2,8 @@ package test
 
 import (
 	"log"
+	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/jinzhu/gorm"
@@ -62,5 +64,18 @@ func TestGormPreload(t *testing.T) {
 		if !allowedValues[*a.Value] {
 			t.Fatalf("unexpected value: '%s'", *a.Value)
 		}
+	}
+}
+
+// This one is not strictly gorm related, but in practice it will probably mostly
+// be used for gorm compatibility.
+func TestCustomAnnotations(t *testing.T) {
+	field, ok := reflect.TypeOf(&models.CustomDefaultUuid{}).Elem().FieldByName("Uuid")
+	if !ok {
+		t.Fatal("field no found")
+	}
+
+	if !strings.Contains(field.Tag.Get("customtag"), "my-custom-tag") {
+		t.Fatal("missing tag")
 	}
 }

--- a/cmd/pggen/test/models/pggen.toml
+++ b/cmd/pggen/test/models/pggen.toml
@@ -358,3 +358,9 @@
         key_field = "small_entity_id"
         one_to_one = true
         parent_field_name = "custom_1to1_reference_name"
+
+[[table]]
+    name = "custom_default_uuids"
+    [[table.field_tags]]
+        column_name = "uuid"
+        tags = "customtag:\"my-custom-tag\""

--- a/gen/gen_table.go
+++ b/gen/gen_table.go
@@ -174,7 +174,7 @@ type {{ .GoName }} struct {
 	{{ .GoName }} {{ .TypeInfo.Name }}
 	{{- end }} ` +
 	"`" + `gorm:"column:{{ .PgName }}"
-	{{- if .IsPrimary }} gorm:"is_primary" {{- end }}` +
+	{{- if .IsPrimary }} gorm:"is_primary" {{- end }} {{ .ExtraTags -}}` +
 	"`" + `
 	{{- end }}
 	{{- range .References }}

--- a/gen/internal/config/config.go
+++ b/gen/internal/config/config.go
@@ -90,6 +90,8 @@ type TableConfig struct {
 	// The timestamp to update in `Update` and `Insert`.
 	// Overriddes global version.
 	UpdatedAtField string `toml:"updated_at_field"`
+	// A list of extra annotations to add to the generated fields.
+	FieldTags []FieldTag `toml:"field_tags"`
 }
 
 // An explicitly configured foreign key relationship which can be attached
@@ -105,6 +107,13 @@ type BelongsTo struct {
 	// Optional. The name to give the pointer field in the generated parent
 	// struct. If not provided, this will just be the name of the child struct.
 	ParentFieldName string `toml:"parent_field_name"`
+}
+
+// Custom annotations to attach to the field generated for a given
+// database column.
+type FieldTag struct {
+	ColumnName string `toml:"column_name"`
+	Tags       string `toml:"tags"`
 }
 
 type TypeOverride struct {

--- a/gen/internal/meta/table_meta.go
+++ b/gen/internal/meta/table_meta.go
@@ -119,68 +119,100 @@ func (tr *tableResolver) populateTableInfo(tables []config.TableConfig) error {
 	}
 
 	// fill in all the allIncludeSpecs
-	for _, info := range tr.meta.tableInfo {
-		err := ensureSpec(tr.meta.tableInfo, info)
+	for _, meta := range tr.meta.tableInfo {
+		err := ensureSpec(tr.meta.tableInfo, meta)
 		if err != nil {
 			return err
 		}
 	}
 
-	for _, info := range tr.meta.tableInfo {
-		tr.setTimestampFlags(info)
+	for _, meta := range tr.meta.tableInfo {
+		tr.setTimestampFlags(meta)
+	}
+
+	for _, meta := range tr.meta.tableInfo {
+		err := populateFieldTags(meta)
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil
 }
 
-func (tr *tableResolver) setTimestampFlags(info *TableMeta) {
-	if len(info.Config.CreatedAtField) > 0 {
-		for _, cm := range info.Info.Cols {
-			if cm.PgName == info.Config.CreatedAtField {
-				info.HasCreatedAtField = true
-				info.CreatedAtFieldIsNullable = cm.Nullable
-				info.CreatedAtHasTimezone = cm.TypeInfo.IsTimestampWithZone
+func populateFieldTags(meta *TableMeta) error {
+	knownCols := make(map[string]bool, len(meta.Info.Cols))
+	for _, col := range meta.Info.Cols {
+		knownCols[col.PgName] = true
+	}
+
+	colToAnn := make(map[string]string, len(meta.Config.FieldTags))
+	for _, ann := range meta.Config.FieldTags {
+		if !knownCols[ann.ColumnName] {
+			return fmt.Errorf("column '%s' is not part of table '%s'", ann.ColumnName, meta.Config.Name)
+		}
+
+		colToAnn[ann.ColumnName] = ann.Tags
+	}
+
+	for i, col := range meta.Info.Cols {
+		meta.Info.Cols[i].ExtraTags = colToAnn[col.PgName]
+		if meta.Info.Cols[i].ExtraTags != "" {
+			println("PING")
+		}
+	}
+
+	return nil
+}
+
+func (tr *tableResolver) setTimestampFlags(meta *TableMeta) {
+	if len(meta.Config.CreatedAtField) > 0 {
+		for _, cm := range meta.Info.Cols {
+			if cm.PgName == meta.Config.CreatedAtField {
+				meta.HasCreatedAtField = true
+				meta.CreatedAtFieldIsNullable = cm.Nullable
+				meta.CreatedAtHasTimezone = cm.TypeInfo.IsTimestampWithZone
 				break
 			}
 		}
 
-		if !info.HasCreatedAtField {
+		if !meta.HasCreatedAtField {
 			tr.log.Warnf(
 				"table '%s' has no '%s' created at timestamp\n",
-				info.Config.Name,
-				info.Config.CreatedAtField,
+				meta.Config.Name,
+				meta.Config.CreatedAtField,
 			)
 		}
 	}
 
-	if len(info.Config.UpdatedAtField) > 0 {
-		for _, cm := range info.Info.Cols {
-			if cm.PgName == info.Config.UpdatedAtField {
-				info.HasUpdateAtField = true
-				info.UpdatedAtFieldIsNullable = cm.Nullable
-				info.UpdatedAtHasTimezone = cm.TypeInfo.IsTimestampWithZone
+	if len(meta.Config.UpdatedAtField) > 0 {
+		for _, cm := range meta.Info.Cols {
+			if cm.PgName == meta.Config.UpdatedAtField {
+				meta.HasUpdateAtField = true
+				meta.UpdatedAtFieldIsNullable = cm.Nullable
+				meta.UpdatedAtHasTimezone = cm.TypeInfo.IsTimestampWithZone
 				break
 			}
 		}
 
-		if !info.HasUpdateAtField {
+		if !meta.HasUpdateAtField {
 			tr.log.Warnf(
 				"table '%s' has no '%s' updated at timestamp\n",
-				info.Config.Name,
-				info.Config.UpdatedAtField,
+				meta.Config.Name,
+				meta.Config.UpdatedAtField,
 			)
 		}
 	}
 }
 
-func ensureSpec(tables map[string]*TableMeta, info *TableMeta) error {
-	if info.AllIncludeSpec != nil {
+func ensureSpec(tables map[string]*TableMeta, meta *TableMeta) error {
+	if meta.AllIncludeSpec != nil {
 		// Some other `ensureSpec` already filled this in for us. Great!
 		return nil
 	}
 
-	info.AllIncludeSpec = &include.Spec{
-		TableName: info.Info.PgName,
+	meta.AllIncludeSpec = &include.Spec{
+		TableName: meta.Info.PgName,
 		Includes:  map[string]*include.Spec{},
 	}
 
@@ -197,20 +229,20 @@ func ensureSpec(tables map[string]*TableMeta, info *TableMeta) error {
 			return err
 		}
 		subSpec := subInfo.AllIncludeSpec
-		info.AllIncludeSpec.Includes[ref.PgPointsFromFieldName] = subSpec
+		meta.AllIncludeSpec.Includes[ref.PgPointsFromFieldName] = subSpec
 
 		return nil
 	}
 
-	for _, ref := range info.AllReferences {
+	for _, ref := range meta.AllReferences {
 		err := ensureReferencedSpec(&ref)
 		if err != nil {
 			return err
 		}
 	}
 
-	if len(info.AllIncludeSpec.Includes) == 0 {
-		info.AllIncludeSpec.Includes = nil
+	if len(meta.AllIncludeSpec.Includes) == 0 {
+		meta.AllIncludeSpec.Includes = nil
 	}
 
 	return nil
@@ -361,6 +393,8 @@ type ColMeta struct {
 	IsPrimary bool
 	// true if this column has a UNIQUE index on it
 	IsUnique bool
+	// extra tags to attach to the generated field
+	ExtraTags string
 }
 
 // Given the name of a table returns metadata about it


### PR DESCRIPTION
This patch adds a new config option so that pggen can
inject custom tags into the generated structs.

Closes #77