### PR TITLE
gorm support: generate foreignKey tags

### DIFF
--- a/cmd/pggen/test/db.sql
+++ b/cmd/pggen/test/db.sql
@@ -306,6 +306,23 @@ CREATE TABLE custom_default_uuids (
     uuid uuid NOT NULL DEFAULT uuid_generate_v4()
 );
 
+CREATE TABLE wacky_roots (
+    id SERIAL PRIMARY KEY NOT NULL,
+    value text NOT NULL
+);
+CREATE TABLE wacky_attachments (
+    id SERIAL PRIMARY KEY NOT NULL,
+    value text NOT NULL,
+    wacky_ref integer NOT NULL
+        REFERENCES wacky_roots(id) ON DELETE RESTRICT ON UPDATE CASCADE
+);
+CREATE TABLE wacky_single_attachments (
+    id SERIAL PRIMARY KEY NOT NULL,
+    value text NOT NULL,
+    wacky_ref integer NOT NULL UNIQUE
+        REFERENCES wacky_roots(id) ON DELETE RESTRICT ON UPDATE CASCADE
+);
+
 --
 -- Load Data
 --

--- a/cmd/pggen/test/models/pggen.toml
+++ b/cmd/pggen/test/models/pggen.toml
@@ -364,3 +364,10 @@
     [[table.field_tags]]
         column_name = "uuid"
         tags = "customtag:\"my-custom-tag\""
+
+[[table]]
+    name = "wacky_roots"
+[[table]]
+    name = "wacky_attachments"
+[[table]]
+    name = "wacky_single_attachments"

--- a/gen/gen_table.go
+++ b/gen/gen_table.go
@@ -158,9 +158,11 @@ type {{ .GoName }} struct {
 	{{- end }}
 	{{- range .IncomingReferences }}
 	{{- if .OneToOne }}
-	{{ .GoPointsFromFieldName }} *{{ .PointsFrom.GoName }}
+	{{ .GoPointsFromFieldName }} *{{ .PointsFrom.GoName }} ` +
+	"`" + `gorm:"foreignKey:{{ .PointsFromField.GoName }}"` + "`" + `
 	{{- else }}
-	{{ .GoPointsFromFieldName }} []*{{ .PointsFrom.GoName }}
+	{{ .GoPointsFromFieldName }} []*{{ .PointsFrom.GoName }} ` +
+	"`" + `gorm:"foreignKey:{{ .PointsFromField.GoName }}"` + "`" + `
 	{{- end }}
 	{{- end }}
 	{{- range .OutgoingReferences }}


### PR DESCRIPTION
This patch teaches pggen how to generate the right foreign
key annoations on the generated structs for good gorm
interop.

Fixes #76 