### PR TITLE
scan: gracefully handle column drops

### DIFF
--- a/cmd/pggen/test/db.sql
+++ b/cmd/pggen/test/db.sql
@@ -328,6 +328,12 @@ CREATE TABLE gorm_defaults (
     uuid uuid NOT NULL DEFAULT uuid_generate_v4()
 );
 
+CREATE TABLE drop_cols (
+    id SERIAL PRIMARY KEY NOT NULL,
+    f1 int NOT NULL DEFAULT 1,
+    f2 int NOT NULL
+);
+
 --
 -- Load Data
 --

--- a/cmd/pggen/test/models/pggen.toml
+++ b/cmd/pggen/test/models/pggen.toml
@@ -377,3 +377,6 @@
     [[table.field_tags]]
         column_name = "uuid"
         tags = "gorm:\"default:'uuid_generate_v4()'\""
+
+[[table]]
+    name = "drop_cols"


### PR DESCRIPTION
This patch teaches the generated scan methods to gracefully
handle dropped columns by refreshing the column index offset
caches.

Fixes #93