### PR TITLE
add first class support for soft deletes

### DIFF
--- a/cmd/pggen/test/cli_test.go
+++ b/cmd/pggen/test/cli_test.go
@@ -273,6 +273,15 @@ name = "small_entities"
 		exitCode: 1,
 		stderrRE: "generating query 'EmptyQueryBody': empty query body",
 	},
+	{
+		toml: `
+[[table]]
+	name = "small_entities"
+	deleted_at_field = "deleted_at"
+		`,
+		exitCode: 0,
+		stderrRE: "WARN: table 'small_entities' has no nullable 'deleted_at' deleted at timestamp",
+	},
 }
 
 func TestCLI(t *testing.T) {

--- a/cmd/pggen/test/db.sql
+++ b/cmd/pggen/test/db.sql
@@ -334,6 +334,19 @@ CREATE TABLE drop_cols (
     f2 int NOT NULL
 );
 
+CREATE TABLE soft_deletables (
+    id SERIAL PRIMARY KEY,
+    value text NOT NULL,
+    deleted_ts timestamp
+);
+CREATE TABLE deletable_leafs (
+    id SERIAL PRIMARY KEY,
+    value text NOT NULL,
+    soft_deletable_id integer NOT NULL
+        REFERENCES soft_deletables(id) ON DELETE RESTRICT ON UPDATE CASCADE,
+    deleted_at timestamp
+);
+
 --
 -- Load Data
 --

--- a/cmd/pggen/test/global_ts_models/pggen.toml
+++ b/cmd/pggen/test/global_ts_models/pggen.toml
@@ -1,6 +1,18 @@
 
+# running go generate for this package should generate the following warnings:
+#
+# WARN: table 'timestamps_global' has no nullable 'deleted_ts' deleted at timestamp
+# WARN: table 'soft_deletables' has no 'created_at' created at timestamp
+# WARN: table 'soft_deletables' has no 'updated_at' updated at timestamp
+#
+# Don't be alarmed if you see them in the output.
+
 created_at_field = "created_at"
 updated_at_field = "updated_at"
+deleted_at_field = "deleted_ts"
 
 [[table]]
     name = "timestamps_global"
+
+[[table]]
+    name = "soft_deletables"

--- a/cmd/pggen/test/models/pggen.toml
+++ b/cmd/pggen/test/models/pggen.toml
@@ -380,3 +380,16 @@
 
 [[table]]
     name = "drop_cols"
+
+[[table]]
+    name = "soft_deletables"
+    # choose a slightly wacky name to prove we have not baked "deleted_at" in
+    deleted_at_field = "deleted_ts"
+# lets us fetch even soft-deleted records
+[[query]]
+    name = "GetSoftDeletableAnyway"
+    return_type = "soft_deletable"
+    body = "SELECT * FROM soft_deletables WHERE id = $1"
+[[table]]
+    name = "deletable_leafs"
+    deleted_at_field = "deleted_at"

--- a/gen/internal/config/config.go
+++ b/gen/internal/config/config.go
@@ -5,12 +5,16 @@ package config
 type DbConfig struct {
 	// The name of the field that should be updated by pggen's generated
 	// `Insert` methods. Overridden by the config option of the same name
-	// on tableConfig.
+	// on TableConfig.
 	CreatedAtField string `toml:"created_at_field"`
 	// The name of the field that should be updated by pggen's generated
 	// `Update` and `Insert` methods. Overridden by the config option of
-	// the same name on tableConfig.
-	UpdatedAtField  string             `toml:"updated_at_field"`
+	// the same name on TableConfig.
+	UpdatedAtField string `toml:"updated_at_field"`
+	// The name of the nullable timestamp field that should be used to
+	// implement soft deletes. Overridden by the config option of the
+	// same name on TableConfig.
+	DeletedAtField  string             `toml:"deleted_at_field"`
 	TypeOverrides   []TypeOverride     `toml:"type_override"`
 	StoredFunctions []StoredFuncConfig `toml:"stored_function"`
 	Queries         []QueryConfig      `toml:"query"`
@@ -90,6 +94,9 @@ type TableConfig struct {
 	// The timestamp to update in `Update` and `Insert`.
 	// Overriddes global version.
 	UpdatedAtField string `toml:"updated_at_field"`
+	// The nullable timestamp for implementing soft deletes.
+	// Overriddes global version.
+	DeletedAtField string `toml:"deleted_at_field"`
 	// A list of extra annotations to add to the generated fields.
 	FieldTags []FieldTag `toml:"field_tags"`
 }
@@ -152,6 +159,10 @@ func (c *DbConfig) Normalize() error {
 
 		if len(tc.UpdatedAtField) == 0 && len(c.UpdatedAtField) > 0 {
 			c.Tables[i].UpdatedAtField = c.UpdatedAtField
+		}
+
+		if len(tc.DeletedAtField) == 0 && len(c.DeletedAtField) > 0 {
+			c.Tables[i].DeletedAtField = c.DeletedAtField
 		}
 	}
 

--- a/gen/internal/meta/meta.go
+++ b/gen/internal/meta/meta.go
@@ -457,12 +457,12 @@ func (mc *Resolver) queryReturns(query string) ([]ColMeta, error) {
 // (a foreign key relationship)
 type RefMeta struct {
 	// The metadata for the table that holds the foreign key
-	PointsTo *PgTableInfo
+	PointsTo *TableMeta
 	// The names of the fields in the referenced table that are used as keys
 	// (usually the primary keys of that table). Order matters.
 	PointsToField *ColMeta
 	// The metadata for the table is being referred to
-	PointsFrom *PgTableInfo
+	PointsFrom *TableMeta
 	// The names of the fields that are being used to refer to the key fields
 	// for the referenced table. Order matters.
 	PointsFromField *ColMeta

--- a/options.go
+++ b/options.go
@@ -36,6 +36,15 @@ type ListOptions struct {
 
 type DeleteOpt func(opts *DeleteOptions)
 type DeleteOptions struct {
+	DoHardDelete bool
+}
+
+// DeleteDoHardDelete tells a delete method to delete the data from the database
+// even if a `deleted_at` timestamp has been configured for soft deletes. If soft
+// deletes have not been configured for the table (via the `deleted_at_field` config
+// key), this flag has no effect.
+func DeleteDoHardDelete(opts *DeleteOptions) {
+	opts.DoHardDelete = true
 }
 
 type UpdateOpt func(opts *UpdateOptions)


### PR DESCRIPTION
This patch adds first class support for soft deletes in the same
way that we already had support for auto-updating created_at/updated_at
timestamp fields.

@NickPPC and @martinxsliu have both brought up this feature recently,
so I thought it would be a good thing to add.

Previously, in order to support soft-deletes one would have to write
custom queries that include checks on the delete field. This is a little
annoying, but still probably ok as long as you know about it. The truely
nasty part of the previous situation is that you would have had to give
up using the include machinery entirely and re-implment your own, which
is sad.

To get a little more concrete about the semantic changes that this patch
includes:
    - There is now a new `deleted_at_field` config key both in the
      global scope and on table configs. Tables override the global
      scope. The value of this key is expected to be the name of a
      nullable timestamp field.
    - The get and list generated methods now respect the configured
      soft-delete timestamp.
    - The delete generated method now soft-deletes rather than blowing
      away all the data if a soft-delete has been configured. The
      DeleteDoHardDelete option from the `pggen` pacakge overrides this
      behavior.
    - The include machinery respects the soft-delete timestamp.

Closes #97