### PR TITLE
run examples as tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,4 +18,4 @@ RUN go mod download
 # into the image itself.
 COPY . ./
 
-CMD bash ./scripts/test.bash
+CMD bash ./tools/test.bash

--- a/Dockerfile.msgv
+++ b/Dockerfile.msgv
@@ -19,4 +19,4 @@ RUN go mod download
 # into the image itself.
 COPY . ./
 
-CMD bash ./scripts/test.bash
+CMD bash ./tools/test.bash

--- a/HACKING.md
+++ b/HACKING.md
@@ -68,6 +68,15 @@ This will both prevent the cli tests from removing their scratch dir and
 compile the binary under test in a debugger friendly format so that you can
 immediately point your delve at it.
 
+## Example Tests
+
+A great way to both document pggen and provide more end-to-end test coverage is to add a
+new example to the `examples` directory. Examples must follow a very specific format in order
+to be run by the test suite. This format is specified in the module comment at the top of
+`examples/examples_test.go`. If you are working on developing just a specific example, it is
+worth knowing about the `PGGEN_TEST_EXAMPLE` environment variable, which can be used to focus
+on one or more examples rather than running the whole suite every time.
+
 ## Errors in the Generated Code
 
 When modifying the output of the codegenerator, you are likely to introduce compile

--- a/cmd/pggen/test/empty_models/generate.go
+++ b/cmd/pggen/test/empty_models/generate.go
@@ -1,3 +1,6 @@
 package empty_models
 
+// make sure that the schema is in place
+//go:generate go run ../../../../tools/ensure-schema/main.go ../db.sql
+
 //go:generate go run ../../main.go -o empty.gen.go pggen.toml

--- a/cmd/pggen/test/global_ts_models/generate.go
+++ b/cmd/pggen/test/global_ts_models/generate.go
@@ -1,3 +1,6 @@
 package global_ts_models
 
+// make sure that the schema is in place
+//go:generate go run ../../../../tools/ensure-schema/main.go ../db.sql
+
 //go:generate go run ./../../main.go -o models.gen.go pggen.toml

--- a/cmd/pggen/test/models/generate.go
+++ b/cmd/pggen/test/models/generate.go
@@ -1,3 +1,6 @@
 package models
 
+// make sure that the schema is in place
+//go:generate go run ../../../../tools/ensure-schema/main.go ../db.sql
+
 //go:generate go run ../../main.go -o models.gen.go pggen.toml

--- a/cmd/pggen/test/overridden_models/generate.go
+++ b/cmd/pggen/test/overridden_models/generate.go
@@ -1,3 +1,6 @@
 package overridden_models
 
+// make sure that the schema is in place
+//go:generate go run ../../../../tools/ensure-schema/main.go ../db.sql
+
 //go:generate go run ../../main.go -o models.gen.go pggen.toml

--- a/cmd/pggen/test/test.go
+++ b/cmd/pggen/test/test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/opendoor-labs/pggen/cmd/pggen/test/models"
+	ensureSchema "github.com/opendoor-labs/pggen/tools/ensure-schema/lib"
 )
 
 var (
@@ -20,6 +21,11 @@ var (
 )
 
 func init() {
+	err := ensureSchema.PopulateDB("./db.sql")
+	if err != nil {
+		log.Fatal(err)
+	}
+
 	dbURL = os.Getenv("DB_URL")
 	if dbURL == "" {
 		log.Fatalf("no DB_URL in the environment")

--- a/examples/README.md
+++ b/examples/README.md
@@ -12,18 +12,21 @@ up to date with the most recent master version of pggen.
 First, `cd` into the example directory, then set up the database
 
 ```bash
-> createdb pggen_example
-> psql pggen_example < db.sql
+> createdb pggen_development
+> psql pggen_development < db.sql
 ```
 
-edit the `models/generate.go` file so that the generate line starts with `//go:generate` instead of
-`// go:generate`, then generate the code
+Make sure that `$DB_URL` is `postgres://localhost/pggen_development?sslmode=disable` either
+by explicitly setting it in the environment with
 
 ```bash
-> go generate ./...
+export DB_URL=postgres://localhost/pggen_development?sslmode=disable
 ```
 
-run the program
+or by installing `direnv` and doing `direnv allow` at the repo root (this will `source` the
+`.envrc` file).
+
+Finally, run the program
 
 ```bash
 > go run ./main.go

--- a/examples/examples_test.go
+++ b/examples/examples_test.go
@@ -1,0 +1,265 @@
+// package examples_test runs each example as a test.
+//
+// In order to be tested by this driver, examples must follow a special pattern. The
+// schema for an example must be defined in a file called `db.sql` in the root of the
+// example directory. This schema file should include the preamble:
+//
+// ```sql
+// DROP SCHEMA public CASCADE;
+// CREATE SCHEMA public;
+// ```
+//
+// This is because the database schema is not garenteed to be empty when the schema file
+// is run.
+//
+// The example must have a file called `main.go` in its root. This serves as the entrypoint
+// to the example.
+//
+// The example must have a file caled `output.txt` in its root. The stdout of the running `main.go`
+// will be checked against this file.
+//
+// The example must have a subdirectory called `models` which contains its generated code. This
+// code will be regenerated and diffed against.
+//
+// In order to focus on just a single example, run with PGGEN_TEST_EXAMPLE=<examples>
+// where <examples> is a comma seperated list of directory names containing the examples
+// to run.
+//
+// By default, this package will test all of the examples found in the examples directory.
+//
+// System Requirements: The `go` tool must be installed as this package shells out to `go run`.
+package examples_test
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path"
+	"regexp"
+	"strings"
+	"testing"
+
+	ensureSchema "github.com/opendoor-labs/pggen/tools/ensure-schema/lib"
+)
+
+// for examples with output that can vary with time, we need to fudge our output
+// matching a little. This table of regular expressions configures that fudging.
+var expectedDiffs = map[string]string{
+	"timestamps": "(?s).*CreatedAt.*UpdatedAt.*CreatedAt.*UpdatedAt.*DeletedAt.*",
+}
+
+func TestExamples(t *testing.T) {
+	examples, err := ioutil.ReadDir(".")
+	chkErr(t, err)
+
+	exampleAllowed := getExampleAllowed()
+
+	for _, e := range examples {
+		if !e.IsDir() {
+			continue
+		}
+
+		if !exampleAllowed(e.Name()) {
+			continue
+		}
+
+		err = runExample(e.Name())
+		chkErr(t, err)
+	}
+
+	// restore standard schema so that unit tests will continue to work if run
+	// afterward
+	err = ensureSchema.PopulateDB(path.Join("..", "cmd", "pggen", "test", "db.sql"))
+	chkErr(t, err)
+}
+
+// runExample runs and tests an example
+func runExample(exampleName string) error {
+	err := generateCode(exampleName)
+	if err != nil {
+		return fmt.Errorf("generating code for '%s': %s", exampleName, err.Error())
+	}
+
+	outputFile, err := os.Open(path.Join(exampleName, "output.txt"))
+	if err != nil {
+		return fmt.Errorf("%s: opening output file: %s", exampleName, err.Error())
+	}
+	defer outputFile.Close()
+	outputReader := bufio.NewReader(outputFile)
+	expectedOutput, err := ioutil.ReadAll(outputReader)
+	if err != nil {
+		return fmt.Errorf("%s: reading output: %s", exampleName, err.Error())
+	}
+
+	runCmd := exec.Command("go", "run", path.Join(exampleName, "main.go"))
+	actualOutput, err := runCmd.Output()
+	if err != nil {
+		return fmt.Errorf("running '%s': %s", exampleName, err.Error())
+	}
+
+	if !bytes.Equal(expectedOutput, actualOutput) {
+		diff, err := displayDiff(expectedOutput, actualOutput)
+		if err != nil {
+			return fmt.Errorf(
+				"%s: error diffing output: %s\nEXPECTED:\n%s\nACTUAL:\n%s\n",
+				exampleName,
+				err.Error(),
+				string(expectedOutput),
+				string(actualOutput),
+			)
+		}
+
+		expectedDiffRE, inMap := expectedDiffs[exampleName]
+		if inMap {
+			re := regexp.MustCompile(expectedDiffRE)
+			if !re.Match(diff) {
+				return fmt.Errorf(
+					"%s: expected diff re /%s/ failed to match diff:\n%s",
+					exampleName,
+					expectedDiffRE,
+					string(diff),
+				)
+			}
+		} else {
+			return fmt.Errorf("%s: different output:\n%s", exampleName, diff)
+		}
+	}
+
+	return nil
+}
+
+var genFileRE = regexp.MustCompile(".*\\.gen\\.go$")
+
+// generateCode generates code for the given example and checks to make sure the result
+// matches up with the code that is checked in.
+func generateCode(exampleName string) error {
+	tmpDir, err := ioutil.TempDir("", "example_test_gen")
+	if err != nil {
+		return fmt.Errorf("creating tmp dir: %s", err.Error())
+	}
+	defer os.RemoveAll(tmpDir)
+
+	// copy the generated files into our scratch space for later diffing
+	modelsDir := path.Join(exampleName, "models")
+	modelsFiles, err := ioutil.ReadDir(modelsDir)
+	if err != nil {
+		return fmt.Errorf("reading models dir: %s", err.Error())
+	}
+	for _, file := range modelsFiles {
+		if !genFileRE.MatchString(file.Name()) {
+			continue
+		}
+		err = copyFile(path.Join(modelsDir, file.Name()), path.Join(tmpDir, file.Name()))
+		if err != nil {
+			return fmt.Errorf("failed to move '%s': %s", path.Join(modelsDir, file.Name()), err.Error())
+		}
+	}
+
+	// actually generate the code
+	genCmd := exec.Command("go", "generate", "./"+exampleName+"/...")
+	err = genCmd.Run()
+	if err != nil {
+		return fmt.Errorf("generating code: %s", err.Error())
+	}
+
+	// diff the generated files against the expected generated code
+	expectedModelsFiles, err := ioutil.ReadDir(tmpDir)
+	if err != nil {
+		return fmt.Errorf("reading tmp dir: %s", err.Error())
+	}
+	for _, file := range expectedModelsFiles {
+		diff, err := displayFileDiff(path.Join(tmpDir, file.Name()), path.Join(modelsDir, file.Name()))
+		if err != nil {
+			return fmt.Errorf("diffing generated code: %s", err.Error())
+		}
+
+		if len(strings.TrimSpace(string(diff))) > 0 {
+			return fmt.Errorf("generated code different than what is checked in:\n%s", string(diff))
+		}
+	}
+
+	return nil
+}
+
+// getAllowedExamples returns a closure which answers if a given example should be run
+func getExampleAllowed() func(exampleName string) bool {
+	focusedExamples, inEnv := os.LookupEnv("PGGEN_TEST_EXAMPLE")
+	if !inEnv {
+		return func(exampleName string) bool {
+			return true
+		}
+	}
+
+	examples := strings.Split(focusedExamples, ",")
+	allowSet := map[string]struct{}{}
+	for _, e := range examples {
+		allowSet[e] = struct{}{}
+	}
+	return func(exampleName string) bool {
+		_, inSet := allowSet[exampleName]
+		return inSet
+	}
+}
+
+// displayDiff dumps the args to files and shells out to `diff` to determine their differences
+func displayDiff(lhs []byte, rhs []byte) ([]byte, error) {
+	tmpDir, err := ioutil.TempDir("", "example_test_diff")
+	if err != nil {
+		return nil, fmt.Errorf("creating tmp dir: %s", err.Error())
+	}
+	defer os.RemoveAll(tmpDir)
+
+	lhsFile := path.Join(tmpDir, "lhs.txt")
+	rhsFile := path.Join(tmpDir, "rhs.txt")
+
+	err = ioutil.WriteFile(lhsFile, lhs, 0400)
+	if err != nil {
+		return nil, fmt.Errorf("writing lhs: %s", err.Error())
+	}
+	err = ioutil.WriteFile(rhsFile, rhs, 0400)
+	if err != nil {
+		return nil, fmt.Errorf("writing lhs: %s", err.Error())
+	}
+
+	return displayFileDiff(lhsFile, rhsFile)
+}
+
+// displayFileDiff shells out to `diff` to diff the two given files
+func displayFileDiff(lhsFile string, rhsFile string) ([]byte, error) {
+	diffCmd := exec.Command("diff", lhsFile, rhsFile)
+	out, err := diffCmd.Output()
+	if err != nil {
+		_, isExitErr := err.(*exec.ExitError)
+		if !isExitErr {
+			return nil, fmt.Errorf("diffing files: %s", err.Error())
+		}
+	}
+
+	return out, nil
+}
+
+func copyFile(src string, dst string) error {
+	source, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer source.Close()
+
+	destination, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	defer destination.Close()
+	_, err = io.Copy(destination, source)
+	return err
+}
+
+func chkErr(t *testing.T, err error) {
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/examples/extending_models/main.go
+++ b/examples/extending_models/main.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"fmt"
 	"log"
+	"os"
 
 	_ "github.com/lib/pq"
 	"github.com/opendoor-labs/pggen/examples/extending_models/models"
@@ -13,7 +14,7 @@ import (
 func main() {
 	ctx := context.Background()
 
-	conn, err := sql.Open("postgres", "postgres://localhost/pggen_example?sslmode=disable")
+	conn, err := sql.Open("postgres", os.Getenv("DB_URL"))
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/examples/extending_models/models/generate.go
+++ b/examples/extending_models/models/generate.go
@@ -1,3 +1,6 @@
 package models
 
-// go:generate go run ../../../cmd/pggen/main.go -o models.gen.go -c postgres://localhost/pggen_example?sslmode=disable pggen.toml
+// make sure that the schema is in place
+//go:generate go run ../../../tools/ensure-schema/main.go ../db.sql
+
+//go:generate go run ../../../cmd/pggen/main.go -o models.gen.go -c $DB_URL pggen.toml

--- a/examples/id_in_set/main.go
+++ b/examples/id_in_set/main.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"fmt"
 	"log"
+	"os"
 	"sort"
 
 	_ "github.com/lib/pq"
@@ -14,7 +15,7 @@ import (
 func main() {
 	ctx := context.Background()
 
-	conn, err := sql.Open("postgres", "postgres://localhost/pggen_example?sslmode=disable")
+	conn, err := sql.Open("postgres", os.Getenv("DB_URL"))
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/examples/id_in_set/models/generate.go
+++ b/examples/id_in_set/models/generate.go
@@ -1,3 +1,6 @@
 package models
 
-// go:generate go run ../../../cmd/pggen/main.go -o models.gen.go -c postgres://localhost/pggen_example?sslmode=disable pggen.toml
+// make sure that the schema is in place
+//go:generate go run ../../../tools/ensure-schema/main.go ../db.sql
+
+//go:generate go run ../../../cmd/pggen/main.go -o models.gen.go -c $DB_URL pggen.toml

--- a/examples/include_specs/main.go
+++ b/examples/include_specs/main.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"fmt"
 	"log"
+	"os"
 
 	_ "github.com/lib/pq"
 	"github.com/opendoor-labs/pggen/examples/include_specs/models"
@@ -14,7 +15,7 @@ import (
 func main() {
 	ctx := context.Background()
 
-	conn, err := sql.Open("postgres", "postgres://localhost/pggen_example?sslmode=disable")
+	conn, err := sql.Open("postgres", os.Getenv("DB_URL"))
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/examples/include_specs/models/generate.go
+++ b/examples/include_specs/models/generate.go
@@ -1,3 +1,6 @@
 package models
 
-// go:generate go run ../../../cmd/pggen/main.go -o models.gen.go -c postgres://localhost/pggen_example?sslmode=disable pggen.toml
+// make sure that the schema is in place
+//go:generate go run ../../../tools/ensure-schema/main.go ../db.sql
+
+//go:generate go run ../../../cmd/pggen/main.go -o models.gen.go -c $DB_URL pggen.toml

--- a/examples/timestamps/main.go
+++ b/examples/timestamps/main.go
@@ -5,18 +5,18 @@ import (
 	"database/sql"
 	"fmt"
 	"log"
+	"os"
 	"time"
 
 	_ "github.com/lib/pq"
-	"github.com/opendoor-labs/pggen/examples/timestamps/models"
 	"github.com/opendoor-labs/pggen"
-	// "github.com/opendoor-labs/pggen/include"
+	"github.com/opendoor-labs/pggen/examples/timestamps/models"
 )
 
 func main() {
 	ctx := context.Background()
 
-	conn, err := sql.Open("postgres", "postgres://localhost/pggen_example?sslmode=disable")
+	conn, err := sql.Open("postgres", os.Getenv("DB_URL"))
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/examples/timestamps/models/generate.go
+++ b/examples/timestamps/models/generate.go
@@ -1,3 +1,6 @@
 package models
 
-// go:generate go run ../../../cmd/pggen/main.go -o models.gen.go -c postgres://localhost/pggen_example?sslmode=disable pggen.toml
+// make sure that the schema is in place
+//go:generate go run ../../../tools/ensure-schema/main.go ../db.sql
+
+//go:generate go run ../../../cmd/pggen/main.go -o models.gen.go -c $DB_URL pggen.toml

--- a/gen/internal/types/type_set.go
+++ b/gen/internal/types/type_set.go
@@ -3,6 +3,7 @@ package types
 import (
 	"fmt"
 	"io"
+	"sort"
 
 	"github.com/opendoor-labs/pggen/gen/internal/utils"
 )
@@ -68,7 +69,16 @@ but another has a return type with fields
 }
 
 func (t *set) gen(into io.Writer) error {
+	decls := make([]typeDecl, len(t.set))
 	for _, decl := range t.set {
+		decls = append(decls, decl)
+	}
+
+	sort.Slice(decls, func(i, j int) bool {
+		return decls[i].sig < decls[j].sig
+	})
+
+	for _, decl := range decls {
 		err := utils.WriteCompletely(into, []byte(decl.body))
 		if err != nil {
 			return err

--- a/tools/ensure-schema/lib/lib.go
+++ b/tools/ensure-schema/lib/lib.go
@@ -1,0 +1,44 @@
+package lib
+
+import (
+	"bufio"
+	"database/sql"
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	_ "github.com/lib/pq" // load postgres driver
+)
+
+// PopulateDB runs `schemaFilePath` against `$DB_URL`
+func PopulateDB(schemaFilePath string) error {
+	// read in the schema
+	schemaFile, err := os.Open(schemaFilePath)
+	if err != nil {
+		return fmt.Errorf("populateDB: missing schema file: %s", err.Error())
+	}
+	defer schemaFile.Close()
+	schemaReader := bufio.NewReader(schemaFile)
+	schema, err := ioutil.ReadAll(schemaReader)
+	if err != nil {
+		return fmt.Errorf("populateDB: reading schema file: %s", err.Error())
+	}
+
+	// connect to the database
+	dbURL, inEnv := os.LookupEnv("DB_URL")
+	if !inEnv {
+		return fmt.Errorf("populateDB: DB_URL must be present in the environment")
+	}
+	db, err := sql.Open("postgres", dbURL)
+	if err != nil {
+		return fmt.Errorf("populateDB: opening connection to database: %s", err.Error())
+	}
+	defer db.Close()
+
+	_, err = db.Exec(string(schema))
+	if err != nil {
+		return fmt.Errorf("populateDB: executing schema: %s", err.Error())
+	}
+
+	return nil
+}

--- a/tools/ensure-schema/main.go
+++ b/tools/ensure-schema/main.go
@@ -1,0 +1,16 @@
+// ensure-schema runs the given schema file against $DB_URL
+package main
+
+import (
+	"log"
+	"os"
+
+	"github.com/opendoor-labs/pggen/tools/ensure-schema/lib"
+)
+
+func main() {
+	err := lib.PopulateDB(os.Args[1])
+	if err != nil {
+		log.Fatal(err)
+	}
+}


### PR DESCRIPTION
This patch turns the collection of examples into runnable tests.
Now the examples will be run when you do:

```
go generate ./... && go test -p 1 ./...
```

An example test checks that the generated code looks like what is
checked in in addition to making sure that the output looks correct.

Because example tests care about the output of the code generated,
I finally tracked down why generated code was not stable across
different machines (#53). The problem was in the way we were printing
the type set (ordering was based on a hash).

Closes #106
Fixes #53