### PR TITLE
fix bug in enum values as stmt arguments

### DIFF
--- a/cmd/pggen/test/models/pggen.toml
+++ b/cmd/pggen/test/models/pggen.toml
@@ -265,6 +265,7 @@
     SELECT text_field_not_null FROM type_rainbow WHERE text_field_not_null = 'this isnt there' LIMIT 1
     '''
 
+
 #
 # Statements
 #
@@ -274,6 +275,10 @@
     body = '''
     INSERT INTO small_entities (anint) VALUES ($1)
     '''
+
+[[statement]]
+    name = "EnumInsertStmt"
+    body = "INSERT INTO funky_enums (enum_val) VALUES ($1)"
 
 #
 # Tables

--- a/cmd/pggen/test/stmts_test.go
+++ b/cmd/pggen/test/stmts_test.go
@@ -2,6 +2,8 @@ package test
 
 import (
 	"testing"
+
+	"github.com/opendoor-labs/pggen/cmd/pggen/test/models"
 )
 
 func TestStmtInsertSmallEntity(t *testing.T) {
@@ -34,6 +36,17 @@ func TestStmtInsertSmallEntity(t *testing.T) {
 	if smallEntities[0].Anint != 719 {
 		t.Fatalf("Unexpected entity (Anint = %d)", smallEntities[0].Anint)
 	}
+}
+
+func TestEnumInsertStatement(t *testing.T) {
+	txClient, err := pgClient.BeginTx(ctx, nil)
+	chkErr(t, err)
+	defer func() {
+		_ = txClient.Rollback()
+	}()
+
+	_, err = txClient.EnumInsertStmt(ctx, models.FunkyNameEnumFoo)
+	chkErr(t, err)
 }
 
 // TODO: once #20 is done, test inserting null enum values using the

--- a/gen/gen_stmt.go
+++ b/gen/gen_stmt.go
@@ -80,7 +80,7 @@ func (p *pgClientImpl) {{ .ConfigData.Name }}(
 	`{{ .ConfigData.Body }}` +
 	"`" + `,
 		{{- range .Args }}
-		{{ .GoName }},
+		{{ call .TypeInfo.SqlArgument .GoName }},
 		{{- end }}
 	)
 }


### PR DESCRIPTION
This patch fixes an issue were we were forgetting to call
SqlArgument on statement parameters to get them in a state
where they are ready to be passed to postgres.

Closes #116