### PR TITLE
fix race in lazy computation of column offset tab

### DIFF
--- a/cmd/pggen/test/db.sql
+++ b/cmd/pggen/test/db.sql
@@ -360,6 +360,13 @@ CREATE TABLE funky_enums (
     enum_val funky_name_enum NOT NULL
 );
 
+-- for exclusive use by the TestOffsetTableFilling test,
+-- will have columns added and removed during testing
+CREATE TABLE offset_table_fillings (
+    id SERIAL PRIMARY KEY,
+    i1 integer NOT NULL
+);
+
 --
 -- Load Data
 --

--- a/cmd/pggen/test/models/escape_hatches.go
+++ b/cmd/pggen/test/models/escape_hatches.go
@@ -1,10 +1,38 @@
 package models
 
+import (
+	"reflect"
+	"unsafe"
+)
+
 // expose some private stuff for testing purposes
 
 func (p *PGClient) ClearCaches() {
-	newClient := PGClient{impl: p.impl, topLevelDB: p.topLevelDB}
-	*p = newClient
+	// It would be nice if we could take advantage of zero values by just clobbering the
+	// PGClient with:
+	//
+	// ```
+	// newClient := PGClient{impl: p.impl, topLevelDB: p.topLevelDB}
+	// *p = newClient
+	// ```
+	//
+	// But then we will be copying/clobbering mutexes which govet is not a fan of.
+
+	v := reflect.ValueOf(p).Elem()
+	emptySlice := []int{}
+	emptySliceV := reflect.ValueOf(emptySlice)
+	for i := 0; i < v.NumField(); i++ {
+		field := v.Field(i)
+		if field.Type().Kind() != reflect.Slice {
+			continue
+		}
+
+		// We resort to unsafe shenannigans to enable us to use reflection to set
+		// unexported fields. We are not really breaking privacy here because the
+		// PGClient type is defined in this module.
+		field = reflect.NewAt(field.Type(), unsafe.Pointer(field.UnsafeAddr())).Elem()
+		field.Set(emptySliceV)
+	}
 }
 
 func (tx *TxPGClient) ClearCaches() {

--- a/cmd/pggen/test/models/pggen.toml
+++ b/cmd/pggen/test/models/pggen.toml
@@ -426,3 +426,6 @@
 
 [[table]]
     name = "funky_enums"
+
+[[table]]
+    name = "offset_table_fillings"

--- a/cmd/pggen/test/race_test.go
+++ b/cmd/pggen/test/race_test.go
@@ -1,0 +1,76 @@
+package test
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/opendoor-labs/pggen/cmd/pggen/test/models"
+)
+
+// file: race_test.go
+//
+// this file contains tests that attempt to exercise potentially racy code
+//
+
+// NOTE: I have been able to confirm that this test will reliably turn up
+//       data races by commenting out all the lock calls in the generated Scan routine
+//       for OffsetTableFilling and then running `go test -race --run TestOffsetTableFilling`
+//       in a loop. Re-generating the models code makes the race warnings go away.
+func TestOffsetTableFilling(t *testing.T) {
+	nscanners := 100
+	nmods := 10
+
+	// insert some data so the results are not empty, not really needed but somehow
+	// makes me fell better.
+	id, err := pgClient.InsertOffsetTableFilling(ctx, &models.OffsetTableFilling{
+		I1: 1,
+	})
+	chkErr(t, err)
+
+	// start mucking about with the table
+	errchan := make(chan error)
+	modRoutine := func() {
+		for i := 0; i < nmods; i++ {
+			_, err := pgClient.Handle().ExecContext(
+				ctx, fmt.Sprintf("ALTER TABLE offset_table_fillings ADD COLUMN i%d integer", i+2))
+			errchan <- err
+		}
+	}
+
+	wg := sync.WaitGroup{}
+	wg.Add(nscanners)
+	scanRoutine := func(tid int) {
+		for i := 0; i < 100; i++ {
+			// don't check the error, as it might be something like
+			// "sorry, too many clients already" or "cached plan must not change result type".
+			// we don't actually care about these issues, we just want to see if we will
+			// get a race with `go test -race`
+			pgClient.GetOffsetTableFilling(ctx, id) // nolint: errcheck
+		}
+		wg.Done()
+	}
+
+	for i := 0; i < (nscanners / 2); i++ {
+		go scanRoutine(i)
+	}
+	go modRoutine()
+	for i := 0; i < (nscanners / 2); i++ {
+		go scanRoutine((nscanners / 2) + i)
+	}
+
+	wg.Wait()
+	for i := 0; i < nmods; i++ {
+		err := <-errchan
+		chkErr(t, err)
+	}
+
+	_, err = pgClient.Handle().ExecContext(ctx, `
+	DROP TABLE offset_table_fillings;
+	CREATE TABLE offset_table_fillings (
+		id SERIAL PRIMARY KEY,
+		i1 integer NOT NULL
+	);
+	`)
+	chkErr(t, err)
+}

--- a/examples/extending_models/models/pggen_prelude.gen.go
+++ b/examples/extending_models/models/pggen_prelude.gen.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	uuid "github.com/satori/go.uuid"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/opendoor-labs/pggen"
@@ -148,18 +149,16 @@ func parenWrap(in string) string {
 func (p *PGClient) fillColPosTab(
 	ctx context.Context,
 	genTimeColIdxTab map[string]int,
-	tableName string,
+	rwlock *sync.RWMutex,
+	rows *sql.Rows,
 	tab *[]int, // out
 ) error {
-	rows, err := p.topLevelDB.QueryContext(ctx, `
-		SELECT a.attname
-		FROM pg_attribute a
-		JOIN pg_class c ON (c.oid = a.attrelid)
-		WHERE a.attisdropped = false AND c.relname = $1 AND a.attnum > 0
-	`, tableName)
-	if err != nil {
-		return err
-	}
+	// We need to ensure that writes to the slice header are atomic. We want to
+	// aquire the lock sooner rather than later to avoid lots of reader goroutines
+	// queuing up computations to compute the position table and causing lock
+	// contention.
+	rwlock.Lock()
+	defer rwlock.Unlock()
 
 	type idxMapping struct {
 		gen int
@@ -167,15 +166,13 @@ func (p *PGClient) fillColPosTab(
 	}
 	indicies := []idxMapping{}
 
-	for i := 0; rows.Next(); i++ {
-		var colName string
-		err = rows.Scan(&colName)
-		if err != nil {
-			return err
-		}
-
-		genIdx, ok := genTimeColIdxTab[colName]
-		if !ok {
+	cols, err := rows.Columns()
+	if err != nil {
+		return fmt.Errorf("reading column names: %s", err.Error())
+	}
+	for i, colName := range cols {
+		genIdx, inTable := genTimeColIdxTab[colName]
+		if !inTable {
 			genIdx = -1 // this is a new column
 		}
 
@@ -187,6 +184,7 @@ func (p *PGClient) fillColPosTab(
 	for _, mapping := range indicies {
 		posTab[mapping.run] = mapping.gen
 	}
+
 	*tab = posTab
 
 	return nil

--- a/examples/id_in_set/models/pggen_prelude.gen.go
+++ b/examples/id_in_set/models/pggen_prelude.gen.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	uuid "github.com/satori/go.uuid"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/opendoor-labs/pggen"
@@ -148,18 +149,16 @@ func parenWrap(in string) string {
 func (p *PGClient) fillColPosTab(
 	ctx context.Context,
 	genTimeColIdxTab map[string]int,
-	tableName string,
+	rwlock *sync.RWMutex,
+	rows *sql.Rows,
 	tab *[]int, // out
 ) error {
-	rows, err := p.topLevelDB.QueryContext(ctx, `
-		SELECT a.attname
-		FROM pg_attribute a
-		JOIN pg_class c ON (c.oid = a.attrelid)
-		WHERE a.attisdropped = false AND c.relname = $1 AND a.attnum > 0
-	`, tableName)
-	if err != nil {
-		return err
-	}
+	// We need to ensure that writes to the slice header are atomic. We want to
+	// aquire the lock sooner rather than later to avoid lots of reader goroutines
+	// queuing up computations to compute the position table and causing lock
+	// contention.
+	rwlock.Lock()
+	defer rwlock.Unlock()
 
 	type idxMapping struct {
 		gen int
@@ -167,15 +166,13 @@ func (p *PGClient) fillColPosTab(
 	}
 	indicies := []idxMapping{}
 
-	for i := 0; rows.Next(); i++ {
-		var colName string
-		err = rows.Scan(&colName)
-		if err != nil {
-			return err
-		}
-
-		genIdx, ok := genTimeColIdxTab[colName]
-		if !ok {
+	cols, err := rows.Columns()
+	if err != nil {
+		return fmt.Errorf("reading column names: %s", err.Error())
+	}
+	for i, colName := range cols {
+		genIdx, inTable := genTimeColIdxTab[colName]
+		if !inTable {
 			genIdx = -1 // this is a new column
 		}
 
@@ -187,6 +184,7 @@ func (p *PGClient) fillColPosTab(
 	for _, mapping := range indicies {
 		posTab[mapping.run] = mapping.gen
 	}
+
 	*tab = posTab
 
 	return nil

--- a/examples/include_specs/models/pggen_prelude.gen.go
+++ b/examples/include_specs/models/pggen_prelude.gen.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	uuid "github.com/satori/go.uuid"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/opendoor-labs/pggen"
@@ -148,18 +149,16 @@ func parenWrap(in string) string {
 func (p *PGClient) fillColPosTab(
 	ctx context.Context,
 	genTimeColIdxTab map[string]int,
-	tableName string,
+	rwlock *sync.RWMutex,
+	rows *sql.Rows,
 	tab *[]int, // out
 ) error {
-	rows, err := p.topLevelDB.QueryContext(ctx, `
-		SELECT a.attname
-		FROM pg_attribute a
-		JOIN pg_class c ON (c.oid = a.attrelid)
-		WHERE a.attisdropped = false AND c.relname = $1 AND a.attnum > 0
-	`, tableName)
-	if err != nil {
-		return err
-	}
+	// We need to ensure that writes to the slice header are atomic. We want to
+	// aquire the lock sooner rather than later to avoid lots of reader goroutines
+	// queuing up computations to compute the position table and causing lock
+	// contention.
+	rwlock.Lock()
+	defer rwlock.Unlock()
 
 	type idxMapping struct {
 		gen int
@@ -167,15 +166,13 @@ func (p *PGClient) fillColPosTab(
 	}
 	indicies := []idxMapping{}
 
-	for i := 0; rows.Next(); i++ {
-		var colName string
-		err = rows.Scan(&colName)
-		if err != nil {
-			return err
-		}
-
-		genIdx, ok := genTimeColIdxTab[colName]
-		if !ok {
+	cols, err := rows.Columns()
+	if err != nil {
+		return fmt.Errorf("reading column names: %s", err.Error())
+	}
+	for i, colName := range cols {
+		genIdx, inTable := genTimeColIdxTab[colName]
+		if !inTable {
 			genIdx = -1 // this is a new column
 		}
 
@@ -187,6 +184,7 @@ func (p *PGClient) fillColPosTab(
 	for _, mapping := range indicies {
 		posTab[mapping.run] = mapping.gen
 	}
+
 	*tab = posTab
 
 	return nil

--- a/examples/middleware/models/models.gen.go
+++ b/examples/middleware/models/models.gen.go
@@ -11,6 +11,7 @@ import (
 	"github.com/opendoor-labs/pggen/include"
 	"github.com/opendoor-labs/pggen/unstable"
 	"strings"
+	"sync"
 )
 
 // PGClient wraps either a 'sql.DB' or a 'sql.Tx'. All pggen-generated
@@ -24,8 +25,12 @@ type PGClient struct {
 	// saw in the table we used to generate code. This means that you don't have to worry
 	// about migrations merging in a slightly different order than their timestamps have
 	// breaking 'SELECT *'.
+	rwlockForFoo    sync.RWMutex
 	colIdxTabForFoo []int
 }
+
+// bogus usage so we can compile with no tables configured
+var _ = sync.RWMutex{}
 
 // NewPGClient creates a new PGClient out of a '*sql.DB' or a
 // custom wrapper around a db connection.
@@ -747,16 +752,20 @@ type Foo struct {
 }
 
 func (r *Foo) Scan(ctx context.Context, client *PGClient, rs *sql.Rows) error {
+	client.rwlockForFoo.RLock()
 	if client.colIdxTabForFoo == nil {
+		client.rwlockForFoo.RUnlock() // release the lock to allow the write lock to be aquired
 		err := client.fillColPosTab(
 			ctx,
 			genTimeColIdxTabForFoo,
-			`foos`,
+			&client.rwlockForFoo,
+			rs,
 			&client.colIdxTabForFoo,
 		)
 		if err != nil {
 			return err
 		}
+		client.rwlockForFoo.RLock() // get the lock back for the rest of the routine
 	}
 
 	var nullableTgts nullableScanTgtsForFoo
@@ -769,6 +778,7 @@ func (r *Foo) Scan(ctx context.Context, client *PGClient, rs *sql.Rows) error {
 			scanTgts[runIdx] = scannerTabForFoo[genIdx](r, &nullableTgts)
 		}
 	}
+	client.rwlockForFoo.RUnlock() // we are now done referencing the idx tab in the happy path
 
 	err := rs.Scan(scanTgts...)
 	if err != nil {
@@ -778,11 +788,14 @@ func (r *Foo) Scan(ctx context.Context, client *PGClient, rs *sql.Rows) error {
 		if colsErr != nil {
 			return fmt.Errorf("pggen: checking column names: %s", colsErr.Error())
 		}
+		client.rwlockForFoo.RLock()
 		if len(client.colIdxTabForFoo) != len(colNames) {
+			client.rwlockForFoo.RUnlock() // release the lock to allow the write lock to be aquired
 			err = client.fillColPosTab(
 				ctx,
 				genTimeColIdxTabForFoo,
-				`drop_cols`,
+				&client.rwlockForFoo,
+				rs,
 				&client.colIdxTabForFoo,
 			)
 			if err != nil {
@@ -791,6 +804,7 @@ func (r *Foo) Scan(ctx context.Context, client *PGClient, rs *sql.Rows) error {
 
 			return r.Scan(ctx, client, rs)
 		} else {
+			client.rwlockForFoo.RUnlock()
 			return err
 		}
 	}

--- a/examples/middleware/models/pggen_prelude.gen.go
+++ b/examples/middleware/models/pggen_prelude.gen.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	uuid "github.com/satori/go.uuid"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/opendoor-labs/pggen"
@@ -148,18 +149,16 @@ func parenWrap(in string) string {
 func (p *PGClient) fillColPosTab(
 	ctx context.Context,
 	genTimeColIdxTab map[string]int,
-	tableName string,
+	rwlock *sync.RWMutex,
+	rows *sql.Rows,
 	tab *[]int, // out
 ) error {
-	rows, err := p.topLevelDB.QueryContext(ctx, `
-		SELECT a.attname
-		FROM pg_attribute a
-		JOIN pg_class c ON (c.oid = a.attrelid)
-		WHERE a.attisdropped = false AND c.relname = $1 AND a.attnum > 0
-	`, tableName)
-	if err != nil {
-		return err
-	}
+	// We need to ensure that writes to the slice header are atomic. We want to
+	// aquire the lock sooner rather than later to avoid lots of reader goroutines
+	// queuing up computations to compute the position table and causing lock
+	// contention.
+	rwlock.Lock()
+	defer rwlock.Unlock()
 
 	type idxMapping struct {
 		gen int
@@ -167,15 +166,13 @@ func (p *PGClient) fillColPosTab(
 	}
 	indicies := []idxMapping{}
 
-	for i := 0; rows.Next(); i++ {
-		var colName string
-		err = rows.Scan(&colName)
-		if err != nil {
-			return err
-		}
-
-		genIdx, ok := genTimeColIdxTab[colName]
-		if !ok {
+	cols, err := rows.Columns()
+	if err != nil {
+		return fmt.Errorf("reading column names: %s", err.Error())
+	}
+	for i, colName := range cols {
+		genIdx, inTable := genTimeColIdxTab[colName]
+		if !inTable {
 			genIdx = -1 // this is a new column
 		}
 
@@ -187,6 +184,7 @@ func (p *PGClient) fillColPosTab(
 	for _, mapping := range indicies {
 		posTab[mapping.run] = mapping.gen
 	}
+
 	*tab = posTab
 
 	return nil

--- a/examples/middleware/output.txt
+++ b/examples/middleware/output.txt
@@ -7,11 +7,5 @@ QueryContext query: INSERT INTO "foos" ("value") VALUES ($1)
 QueryRowContext query: UPDATE "foos" SET ("id","value") = ($1, $2) WHERE "id" = $3 RETURNING "id"
 ExecContext query: DELETE FROM "foos" WHERE "id" = ANY($1)
 QueryContext query: SELECT * FROM "foos" WHERE "id" = ANY($1)
-QueryContext query: 
-		SELECT a.attname
-		FROM pg_attribute a
-		JOIN pg_class c ON (c.oid = a.attrelid)
-		WHERE a.attisdropped = false AND c.relname = $1 AND a.attnum > 0
-	
 bax
 lish

--- a/examples/query_argument_names/models/pggen_prelude.gen.go
+++ b/examples/query_argument_names/models/pggen_prelude.gen.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	uuid "github.com/satori/go.uuid"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/opendoor-labs/pggen"
@@ -148,18 +149,16 @@ func parenWrap(in string) string {
 func (p *PGClient) fillColPosTab(
 	ctx context.Context,
 	genTimeColIdxTab map[string]int,
-	tableName string,
+	rwlock *sync.RWMutex,
+	rows *sql.Rows,
 	tab *[]int, // out
 ) error {
-	rows, err := p.topLevelDB.QueryContext(ctx, `
-		SELECT a.attname
-		FROM pg_attribute a
-		JOIN pg_class c ON (c.oid = a.attrelid)
-		WHERE a.attisdropped = false AND c.relname = $1 AND a.attnum > 0
-	`, tableName)
-	if err != nil {
-		return err
-	}
+	// We need to ensure that writes to the slice header are atomic. We want to
+	// aquire the lock sooner rather than later to avoid lots of reader goroutines
+	// queuing up computations to compute the position table and causing lock
+	// contention.
+	rwlock.Lock()
+	defer rwlock.Unlock()
 
 	type idxMapping struct {
 		gen int
@@ -167,15 +166,13 @@ func (p *PGClient) fillColPosTab(
 	}
 	indicies := []idxMapping{}
 
-	for i := 0; rows.Next(); i++ {
-		var colName string
-		err = rows.Scan(&colName)
-		if err != nil {
-			return err
-		}
-
-		genIdx, ok := genTimeColIdxTab[colName]
-		if !ok {
+	cols, err := rows.Columns()
+	if err != nil {
+		return fmt.Errorf("reading column names: %s", err.Error())
+	}
+	for i, colName := range cols {
+		genIdx, inTable := genTimeColIdxTab[colName]
+		if !inTable {
 			genIdx = -1 // this is a new column
 		}
 
@@ -187,6 +184,7 @@ func (p *PGClient) fillColPosTab(
 	for _, mapping := range indicies {
 		posTab[mapping.run] = mapping.gen
 	}
+
 	*tab = posTab
 
 	return nil

--- a/examples/single_results/models/models.gen.go
+++ b/examples/single_results/models/models.gen.go
@@ -11,6 +11,7 @@ import (
 	"github.com/opendoor-labs/pggen/include"
 	"github.com/opendoor-labs/pggen/unstable"
 	"strings"
+	"sync"
 )
 
 // PGClient wraps either a 'sql.DB' or a 'sql.Tx'. All pggen-generated
@@ -24,8 +25,12 @@ type PGClient struct {
 	// saw in the table we used to generate code. This means that you don't have to worry
 	// about migrations merging in a slightly different order than their timestamps have
 	// breaking 'SELECT *'.
+	rwlockForFoo    sync.RWMutex
 	colIdxTabForFoo []int
 }
+
+// bogus usage so we can compile with no tables configured
+var _ = sync.RWMutex{}
 
 // NewPGClient creates a new PGClient out of a '*sql.DB' or a
 // custom wrapper around a db connection.
@@ -816,16 +821,20 @@ type Foo struct {
 }
 
 func (r *Foo) Scan(ctx context.Context, client *PGClient, rs *sql.Rows) error {
+	client.rwlockForFoo.RLock()
 	if client.colIdxTabForFoo == nil {
+		client.rwlockForFoo.RUnlock() // release the lock to allow the write lock to be aquired
 		err := client.fillColPosTab(
 			ctx,
 			genTimeColIdxTabForFoo,
-			`foos`,
+			&client.rwlockForFoo,
+			rs,
 			&client.colIdxTabForFoo,
 		)
 		if err != nil {
 			return err
 		}
+		client.rwlockForFoo.RLock() // get the lock back for the rest of the routine
 	}
 
 	var nullableTgts nullableScanTgtsForFoo
@@ -838,6 +847,7 @@ func (r *Foo) Scan(ctx context.Context, client *PGClient, rs *sql.Rows) error {
 			scanTgts[runIdx] = scannerTabForFoo[genIdx](r, &nullableTgts)
 		}
 	}
+	client.rwlockForFoo.RUnlock() // we are now done referencing the idx tab in the happy path
 
 	err := rs.Scan(scanTgts...)
 	if err != nil {
@@ -847,11 +857,14 @@ func (r *Foo) Scan(ctx context.Context, client *PGClient, rs *sql.Rows) error {
 		if colsErr != nil {
 			return fmt.Errorf("pggen: checking column names: %s", colsErr.Error())
 		}
+		client.rwlockForFoo.RLock()
 		if len(client.colIdxTabForFoo) != len(colNames) {
+			client.rwlockForFoo.RUnlock() // release the lock to allow the write lock to be aquired
 			err = client.fillColPosTab(
 				ctx,
 				genTimeColIdxTabForFoo,
-				`drop_cols`,
+				&client.rwlockForFoo,
+				rs,
 				&client.colIdxTabForFoo,
 			)
 			if err != nil {
@@ -860,6 +873,7 @@ func (r *Foo) Scan(ctx context.Context, client *PGClient, rs *sql.Rows) error {
 
 			return r.Scan(ctx, client, rs)
 		} else {
+			client.rwlockForFoo.RUnlock()
 			return err
 		}
 	}

--- a/examples/single_results/models/pggen_prelude.gen.go
+++ b/examples/single_results/models/pggen_prelude.gen.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	uuid "github.com/satori/go.uuid"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/opendoor-labs/pggen"
@@ -148,18 +149,16 @@ func parenWrap(in string) string {
 func (p *PGClient) fillColPosTab(
 	ctx context.Context,
 	genTimeColIdxTab map[string]int,
-	tableName string,
+	rwlock *sync.RWMutex,
+	rows *sql.Rows,
 	tab *[]int, // out
 ) error {
-	rows, err := p.topLevelDB.QueryContext(ctx, `
-		SELECT a.attname
-		FROM pg_attribute a
-		JOIN pg_class c ON (c.oid = a.attrelid)
-		WHERE a.attisdropped = false AND c.relname = $1 AND a.attnum > 0
-	`, tableName)
-	if err != nil {
-		return err
-	}
+	// We need to ensure that writes to the slice header are atomic. We want to
+	// aquire the lock sooner rather than later to avoid lots of reader goroutines
+	// queuing up computations to compute the position table and causing lock
+	// contention.
+	rwlock.Lock()
+	defer rwlock.Unlock()
 
 	type idxMapping struct {
 		gen int
@@ -167,15 +166,13 @@ func (p *PGClient) fillColPosTab(
 	}
 	indicies := []idxMapping{}
 
-	for i := 0; rows.Next(); i++ {
-		var colName string
-		err = rows.Scan(&colName)
-		if err != nil {
-			return err
-		}
-
-		genIdx, ok := genTimeColIdxTab[colName]
-		if !ok {
+	cols, err := rows.Columns()
+	if err != nil {
+		return fmt.Errorf("reading column names: %s", err.Error())
+	}
+	for i, colName := range cols {
+		genIdx, inTable := genTimeColIdxTab[colName]
+		if !inTable {
 			genIdx = -1 // this is a new column
 		}
 
@@ -187,6 +184,7 @@ func (p *PGClient) fillColPosTab(
 	for _, mapping := range indicies {
 		posTab[mapping.run] = mapping.gen
 	}
+
 	*tab = posTab
 
 	return nil

--- a/examples/timestamps/models/models.gen.go
+++ b/examples/timestamps/models/models.gen.go
@@ -11,6 +11,7 @@ import (
 	"github.com/opendoor-labs/pggen/include"
 	"github.com/opendoor-labs/pggen/unstable"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -25,8 +26,12 @@ type PGClient struct {
 	// saw in the table we used to generate code. This means that you don't have to worry
 	// about migrations merging in a slightly different order than their timestamps have
 	// breaking 'SELECT *'.
+	rwlockForUser    sync.RWMutex
 	colIdxTabForUser []int
 }
+
+// bogus usage so we can compile with no tables configured
+var _ = sync.RWMutex{}
 
 // NewPGClient creates a new PGClient out of a '*sql.DB' or a
 // custom wrapper around a db connection.
@@ -915,16 +920,20 @@ type User struct {
 }
 
 func (r *User) Scan(ctx context.Context, client *PGClient, rs *sql.Rows) error {
+	client.rwlockForUser.RLock()
 	if client.colIdxTabForUser == nil {
+		client.rwlockForUser.RUnlock() // release the lock to allow the write lock to be aquired
 		err := client.fillColPosTab(
 			ctx,
 			genTimeColIdxTabForUser,
-			`users`,
+			&client.rwlockForUser,
+			rs,
 			&client.colIdxTabForUser,
 		)
 		if err != nil {
 			return err
 		}
+		client.rwlockForUser.RLock() // get the lock back for the rest of the routine
 	}
 
 	var nullableTgts nullableScanTgtsForUser
@@ -937,6 +946,7 @@ func (r *User) Scan(ctx context.Context, client *PGClient, rs *sql.Rows) error {
 			scanTgts[runIdx] = scannerTabForUser[genIdx](r, &nullableTgts)
 		}
 	}
+	client.rwlockForUser.RUnlock() // we are now done referencing the idx tab in the happy path
 
 	err := rs.Scan(scanTgts...)
 	if err != nil {
@@ -946,11 +956,14 @@ func (r *User) Scan(ctx context.Context, client *PGClient, rs *sql.Rows) error {
 		if colsErr != nil {
 			return fmt.Errorf("pggen: checking column names: %s", colsErr.Error())
 		}
+		client.rwlockForUser.RLock()
 		if len(client.colIdxTabForUser) != len(colNames) {
+			client.rwlockForUser.RUnlock() // release the lock to allow the write lock to be aquired
 			err = client.fillColPosTab(
 				ctx,
 				genTimeColIdxTabForUser,
-				`drop_cols`,
+				&client.rwlockForUser,
+				rs,
 				&client.colIdxTabForUser,
 			)
 			if err != nil {
@@ -959,6 +972,7 @@ func (r *User) Scan(ctx context.Context, client *PGClient, rs *sql.Rows) error {
 
 			return r.Scan(ctx, client, rs)
 		} else {
+			client.rwlockForUser.RUnlock()
 			return err
 		}
 	}

--- a/examples/timestamps/models/pggen_prelude.gen.go
+++ b/examples/timestamps/models/pggen_prelude.gen.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	uuid "github.com/satori/go.uuid"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/opendoor-labs/pggen"
@@ -148,18 +149,16 @@ func parenWrap(in string) string {
 func (p *PGClient) fillColPosTab(
 	ctx context.Context,
 	genTimeColIdxTab map[string]int,
-	tableName string,
+	rwlock *sync.RWMutex,
+	rows *sql.Rows,
 	tab *[]int, // out
 ) error {
-	rows, err := p.topLevelDB.QueryContext(ctx, `
-		SELECT a.attname
-		FROM pg_attribute a
-		JOIN pg_class c ON (c.oid = a.attrelid)
-		WHERE a.attisdropped = false AND c.relname = $1 AND a.attnum > 0
-	`, tableName)
-	if err != nil {
-		return err
-	}
+	// We need to ensure that writes to the slice header are atomic. We want to
+	// aquire the lock sooner rather than later to avoid lots of reader goroutines
+	// queuing up computations to compute the position table and causing lock
+	// contention.
+	rwlock.Lock()
+	defer rwlock.Unlock()
 
 	type idxMapping struct {
 		gen int
@@ -167,15 +166,13 @@ func (p *PGClient) fillColPosTab(
 	}
 	indicies := []idxMapping{}
 
-	for i := 0; rows.Next(); i++ {
-		var colName string
-		err = rows.Scan(&colName)
-		if err != nil {
-			return err
-		}
-
-		genIdx, ok := genTimeColIdxTab[colName]
-		if !ok {
+	cols, err := rows.Columns()
+	if err != nil {
+		return fmt.Errorf("reading column names: %s", err.Error())
+	}
+	for i, colName := range cols {
+		genIdx, inTable := genTimeColIdxTab[colName]
+		if !inTable {
 			genIdx = -1 // this is a new column
 		}
 
@@ -187,6 +184,7 @@ func (p *PGClient) fillColPosTab(
 	for _, mapping := range indicies {
 		posTab[mapping.run] = mapping.gen
 	}
+
 	*tab = posTab
 
 	return nil

--- a/gen/gen_pgclient.go
+++ b/gen/gen_pgclient.go
@@ -11,6 +11,7 @@ import (
 func (g *Generator) genPGClient(into io.Writer, tables []config.TableConfig) error {
 	g.imports[`"github.com/opendoor-labs/pggen"`] = true
 	g.imports[`"database/sql"`] = true
+	g.imports[`"sync"`] = true
 
 	type genCtx struct {
 		ModelNames []string
@@ -40,9 +41,13 @@ type PGClient struct {
 	// about migrations merging in a slightly different order than their timestamps have
 	// breaking 'SELECT *'.
 	{{- range .ModelNames }}
+	rwlockFor{{ . }} sync.RWMutex
 	colIdxTabFor{{ . }} []int
 	{{- end }}
 }
+
+// bogus usage so we can compile with no tables configured
+var _ = sync.RWMutex{}
 
 // NewPGClient creates a new PGClient out of a '*sql.DB' or a
 // custom wrapper around a db connection.

--- a/tools/test.bash
+++ b/tools/test.bash
@@ -31,8 +31,11 @@ psql "$DB_URL" < cmd/pggen/test/db.sql
 
 if [[ -n "${LINT+x}" ]] ; then
     golangci-lint run -E gofmt -E gosec -E gocyclo -E deadcode
+elif go version | grep '1.11' 2>&1 >/dev/null ; then
+    # for some reason the race detector acts weird with go 1.11
+    go test -p 1 ./...
 else
     # We have to serialize the tests because the example tests will re-write the database
     # schema dynamically. We could fix this by creating a dedicated database for the example tests.
-    go test -p 1 ./...
+    go test -race -p 1 ./...
 fi


### PR DESCRIPTION
This patch fixes a race in the way that the column offset
tables were getting computed. Previously, multiple goroutines
could attempt to Scan a record of the same type at once and
then compute the offset table at the same time. They could
then write different slice headers at the same time, potentially
corrupting data.

The fix is to guard each offset table with a RWMutex. The scan
routine acquires a read lock whenever it accesses the table and
the update routine acquires a write lock before updating it.
We could make the critical section for the update routine shorter
(by just wrapping the actual slice update), but I thought it would
be better to prevent readers from enqueueing more writers and
causing thrash. I did not really benchmark this.

This race is mostly theoretical, and I didn't really try to get
a test that reproduces the issue (though maybe I should take a
look at the race detector for this?)

In any case, I'd appreciate a good close reading of this patch
because multithreading is always tricky. In particular, we want
to make sure that:
    - Scan has released all locks by the time it returns (I needed
      fairly fine grained control of when the lock was held so I
      had to kick it C style rather than using defer).
    - No read lock can ever be held by a given goroutine when it calls
      fillColPosTab, as this would deadlock.

Fixes #115