### PR TITLE
consolidate scan struct implementation

### DIFF
--- a/examples/id_in_set/models/models.gen.go
+++ b/examples/id_in_set/models/models.gen.go
@@ -25,8 +25,10 @@ type PGClient struct {
 	// saw in the table we used to generate code. This means that you don't have to worry
 	// about migrations merging in a slightly different order than their timestamps have
 	// breaking 'SELECT *'.
-	rwlockForFoo    sync.RWMutex
-	colIdxTabForFoo []int
+	rwlockForFoo                sync.RWMutex
+	colIdxTabForFoo             []int
+	rwlockForGetFooValuesRow    sync.RWMutex
+	colIdxTabForGetFooValuesRow []int
 }
 
 // bogus usage so we can compile with no tables configured

--- a/examples/query_argument_names/models/models.gen.go
+++ b/examples/query_argument_names/models/models.gen.go
@@ -25,8 +25,10 @@ type PGClient struct {
 	// saw in the table we used to generate code. This means that you don't have to worry
 	// about migrations merging in a slightly different order than their timestamps have
 	// breaking 'SELECT *'.
-	rwlockForUser    sync.RWMutex
-	colIdxTabForUser []int
+	rwlockForUser                           sync.RWMutex
+	colIdxTabForUser                        []int
+	rwlockForGetUserByEmailOrNicknameRow    sync.RWMutex
+	colIdxTabForGetUserByEmailOrNicknameRow []int
 }
 
 // bogus usage so we can compile with no tables configured

--- a/examples/single_results/models/models.gen.go
+++ b/examples/single_results/models/models.gen.go
@@ -25,8 +25,10 @@ type PGClient struct {
 	// saw in the table we used to generate code. This means that you don't have to worry
 	// about migrations merging in a slightly different order than their timestamps have
 	// breaking 'SELECT *'.
-	rwlockForFoo    sync.RWMutex
-	colIdxTabForFoo []int
+	rwlockForFoo                 sync.RWMutex
+	colIdxTabForFoo              []int
+	rwlockForMyGetFooValueRow    sync.RWMutex
+	colIdxTabForMyGetFooValueRow []int
 }
 
 // bogus usage so we can compile with no tables configured

--- a/examples/timestamps/models/models.gen.go
+++ b/examples/timestamps/models/models.gen.go
@@ -26,8 +26,10 @@ type PGClient struct {
 	// saw in the table we used to generate code. This means that you don't have to worry
 	// about migrations merging in a slightly different order than their timestamps have
 	// breaking 'SELECT *'.
-	rwlockForUser    sync.RWMutex
-	colIdxTabForUser []int
+	rwlockForUser                sync.RWMutex
+	colIdxTabForUser             []int
+	rwlockForGetUserAnywayRow    sync.RWMutex
+	colIdxTabForGetUserAnywayRow []int
 }
 
 // bogus usage so we can compile with no tables configured

--- a/gen/gen.go
+++ b/gen/gen.go
@@ -156,7 +156,7 @@ func (g *Generator) Gen() error {
 
 	var body strings.Builder
 
-	err = g.genPGClient(&body, conf.Tables)
+	err = g.genPGClient(&body, conf)
 	if err != nil {
 		return err
 	}

--- a/gen/gen_table.go
+++ b/gen/gen_table.go
@@ -3,7 +3,6 @@ package gen
 import (
 	"fmt"
 	"io"
-	"strings"
 	"text/template"
 
 	"github.com/opendoor-labs/pggen/gen/internal/config"
@@ -38,24 +37,8 @@ func (g *Generator) genTables(into io.Writer, tables []config.TableConfig) error
 	return nil
 }
 
-// This genctx duplicates info already stored in the Meta member, but it is
-// a nice quality of life improvement to have some of the really commonly refered
-// data bubbled up to the top level.
-type tableGenCtx struct {
-	// taken from Meta
-	PgName string
-	// taken from Meta
-	GoName string
-	// taken from Meta
-	PkeyCol *meta.ColMeta
-	// taken from Meta
-	PkeyColIdx     int
-	AllIncludeSpec string
-	Meta           *meta.TableMeta
-}
-
-func tableGenCtxFromInfo(info *meta.TableMeta) tableGenCtx {
-	return tableGenCtx{
+func tableGenCtxFromInfo(info *meta.TableMeta) meta.TableGenCtx {
+	return meta.TableGenCtx{
 		PgName:         info.Info.PgName,
 		GoName:         info.Info.GoName,
 		PkeyCol:        info.Info.PkeyCol,
@@ -92,159 +75,13 @@ func (g *Generator) genTable(
 		g.imports[`"time"`] = true
 	}
 
-	// Emit the type seperately to prevent double defintions
-	var tableType strings.Builder
-	err = tableTypeTmpl.Execute(&tableType, genCtx)
-	if err != nil {
-		return
-	}
-	var tableSig strings.Builder
-	err = tableTypeFieldSigTmpl.Execute(&tableSig, genCtx)
-	if err != nil {
-		return
-	}
-	err = g.typeResolver.EmitType(genCtx.GoName, tableSig.String(), tableType.String())
+	err = g.typeResolver.EmitStructType(genCtx.GoName, genCtx)
 	if err != nil {
 		return
 	}
 
 	return tableShimTmpl.Execute(into, genCtx)
 }
-
-var tableTypeFieldSigTmpl *template.Template = template.Must(template.New("table-type-field-sig-tmpl").Parse(`
-{{- range .Meta.Info.Cols }}
-{{- if .Nullable }}
-{{ .GoName }} {{ .TypeInfo.NullName }}
-{{- else }}
-{{ .GoName }} {{ .TypeInfo.Name }}
-{{- end }}
-{{- end }}
-`))
-
-var tableTypeTmpl *template.Template = template.Must(template.New("table-type-tmpl").Parse(`
-type {{ .GoName }} struct {
-	{{- range .Meta.Info.Cols }}
-	{{- if .Nullable }}
-	{{ .GoName }} {{ .TypeInfo.NullName }}
-	{{- else }}
-	{{ .GoName }} {{ .TypeInfo.Name }}
-	{{- end }} ` +
-	"`" + `{{ .Tags }}` + "`" + `
-	{{- end }}
-	{{- range .Meta.AllIncomingReferences }}
-	{{- if .OneToOne }}
-	{{ .GoPointsFromFieldName }} *{{ .PointsFrom.Info.GoName }} ` +
-	"`" + `gorm:"foreignKey:{{ .PointsFromField.GoName }}"` + "`" + `
-	{{- else }}
-	{{ .GoPointsFromFieldName }} []*{{ .PointsFrom.Info.GoName }} ` +
-	"`" + `gorm:"foreignKey:{{ .PointsFromField.GoName }}"` + "`" + `
-	{{- end }}
-	{{- end }}
-	{{- range .Meta.AllOutgoingReferences }}
-	{{- /* All outgoing references are 1-1, so we don't check the .OneToOne flag */}}
-	{{ .GoPointsToFieldName }} *{{ .PointsTo.Info.GoName }}
-	{{- end}}
-}
-func (r *{{ .GoName }}) Scan(ctx context.Context, client *PGClient, rs *sql.Rows) error {
-	client.rwlockFor{{ .GoName }}.RLock()
-	if client.colIdxTabFor{{ .GoName }} == nil {
-		client.rwlockFor{{ .GoName }}.RUnlock() // release the lock to allow the write lock to be aquired
-		err := client.fillColPosTab(
-			ctx,
-			genTimeColIdxTabFor{{ .GoName }},
-			&client.rwlockFor{{ .GoName }},
-			rs,
-			&client.colIdxTabFor{{ .GoName }},
-		)
-		if err != nil {
-			return err
-		}
-		client.rwlockFor{{ .GoName }}.RLock() // get the lock back for the rest of the routine
-	}
-
-	var nullableTgts nullableScanTgtsFor{{ .GoName }}
-
-	scanTgts := make([]interface{}, len(client.colIdxTabFor{{ .GoName }}))
-	for runIdx, genIdx := range client.colIdxTabFor{{ .GoName }} {
-		if genIdx == -1 {
-			scanTgts[runIdx] = &pggenSinkScanner{}
-		} else {
-			scanTgts[runIdx] = scannerTabFor{{ .GoName }}[genIdx](r, &nullableTgts)
-		}
-	}
-	client.rwlockFor{{ .GoName }}.RUnlock() // we are now done referencing the idx tab in the happy path
-
-	err := rs.Scan(scanTgts...)
-	if err != nil {
-		// The database schema may have been changed out from under us, let's
-		// check to see if we just need to update our column index tables and retry.
-		colNames, colsErr := rs.Columns()
-		if colsErr != nil {
-			return fmt.Errorf("pggen: checking column names: %s", colsErr.Error())
-		}
-		client.rwlockFor{{ .GoName }}.RLock()
-		if len(client.colIdxTabFor{{ .GoName }}) != len(colNames) {
-			client.rwlockFor{{ .GoName }}.RUnlock() // release the lock to allow the write lock to be aquired
-			err = client.fillColPosTab(
-				ctx,
-				genTimeColIdxTabFor{{ .GoName }},
-				&client.rwlockFor{{ .GoName }},
-				rs,
-				&client.colIdxTabFor{{ .GoName }},
-			)
-			if err != nil {
-				return err
-			}
-
-			return r.Scan(ctx, client, rs)
-		} else {
-			client.rwlockFor{{ .GoName }}.RUnlock()
-			return err
-		}
-	}
-
-	{{- range .Meta.Info.Cols }}
-	{{- if .Nullable }}
-	r.{{ .GoName }} = {{ call .TypeInfo.NullConvertFunc (printf "nullableTgts.scan%s" .GoName) }}
-	{{- else if (eq .TypeInfo.Name "time.Time") }}
-	r.{{ .GoName }} = {{ printf "nullableTgts.scan%s" .GoName }}.Time
-	{{- end }}
-	{{- end }}
-
-	return nil
-}
-
-type nullableScanTgtsFor{{ .GoName }} struct {
-	{{- range .Meta.Info.Cols }}
-	{{- if (or .Nullable (eq .TypeInfo.Name "time.Time")) }}
-	scan{{ .GoName }} {{ .TypeInfo.ScanNullName }}
-	{{- end }}
-	{{- end }}
-}
-
-// a table mapping codegen-time col indicies to functions returning a scanner for the
-// field that was at that column index at codegen-time.
-var scannerTabFor{{ .GoName }} = [...]func(*{{ .GoName }}, *nullableScanTgtsFor{{ .GoName }}) interface{} {
-	{{- range .Meta.Info.Cols }}
-	func (
-		r *{{ $.GoName }},
-		nullableTgts *nullableScanTgtsFor{{ $.GoName }},
-	) interface{} {
-		{{- if (or .Nullable (eq .TypeInfo.Name "time.Time")) }}
-		return {{ call .TypeInfo.NullSqlReceiver (printf "nullableTgts.scan%s" .GoName) }}
-		{{- else }}
-		return {{ call .TypeInfo.SqlReceiver (printf "r.%s" .GoName) }}
-		{{- end }}
-	},
-	{{- end }}
-}
-
-var genTimeColIdxTabFor{{ .GoName }} map[string]int = map[string]int{
-	{{- range $i, $col := .Meta.Info.Cols }}
-	` + "`" + `{{ $col.PgName }}` + "`" + `: {{ $i }},
-	{{- end }}
-}
-`))
 
 var tableShimTmpl *template.Template = template.Must(template.New("table-shim-tmpl").Parse(`
 

--- a/gen/internal/meta/table_meta.go
+++ b/gen/internal/meta/table_meta.go
@@ -90,6 +90,22 @@ type TableMeta struct {
 	Info PgTableInfo
 }
 
+// This genctx duplicates info already stored in the Meta member, but it is
+// a nice quality of life improvement to have some of the really commonly refered
+// to data bubbled up to the top level.
+type TableGenCtx struct {
+	// taken from Meta
+	PgName string
+	// taken from Meta
+	GoName string
+	// taken from Meta
+	PkeyCol *ColMeta
+	// taken from Meta
+	PkeyColIdx     int
+	AllIncludeSpec string
+	Meta           *TableMeta
+}
+
 // nullFlags computes the null flags specifying the nullness of this
 // table in the same format used by the `null_flags` config option
 func (info TableMeta) nullFlags() string {

--- a/gen/internal/types/gen_struct.go
+++ b/gen/internal/types/gen_struct.go
@@ -1,0 +1,171 @@
+package types
+
+import (
+	"strings"
+	"text/template"
+)
+
+// file: gen_struct.go
+// This file exposes an interface for generating a struct with a Scan routine.
+// It is shared between the code for generating a query return value and the
+// code for generating table code.
+
+// genCtx should be a meta.TableGenCtx. We ask for an interface{} param to avoid a cyclic
+// dependency. Using an interface{} is fine because we are just going to pass it into the
+// template evaluator anyway.
+func (r *Resolver) EmitStructType(typeName string, genCtx interface{}) error {
+	var typeBody strings.Builder
+	err := structTypeTmpl.Execute(&typeBody, genCtx)
+	if err != nil {
+		return err
+	}
+
+	var typeSig strings.Builder
+	err = structTypeSigTmpl.Execute(&typeSig, genCtx)
+	if err != nil {
+		return err
+	}
+
+	sigTxt := typeSig.String()
+	bodyTxt := typeBody.String()
+	err = r.EmitType(typeName, sigTxt, bodyTxt) //typeSig.String(), typeBody.String())
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+var structTypeSigTmpl *template.Template = template.Must(template.New("table-type-field-sig-tmpl").Parse(`
+{{- range .Meta.Info.Cols }}
+{{- if .Nullable }}
+{{ .GoName }} {{ .TypeInfo.NullName }}
+{{- else }}
+{{ .GoName }} {{ .TypeInfo.Name }}
+{{- end }}
+{{- end }}
+`))
+
+var structTypeTmpl *template.Template = template.Must(template.New("struct-type-tmpl").Parse(`
+type {{ .GoName }} struct {
+	{{- range .Meta.Info.Cols }}
+	{{- if .Nullable }}
+	{{ .GoName }} {{ .TypeInfo.NullName }}
+	{{- else }}
+	{{ .GoName }} {{ .TypeInfo.Name }}
+	{{- end }} ` +
+	"`" + `{{ .Tags }}` + "`" + `
+	{{- end }}
+	{{- range .Meta.AllIncomingReferences }}
+	{{- if .OneToOne }}
+	{{ .GoPointsFromFieldName }} *{{ .PointsFrom.Info.GoName }} ` +
+	"`" + `gorm:"foreignKey:{{ .PointsFromField.GoName }}"` + "`" + `
+	{{- else }}
+	{{ .GoPointsFromFieldName }} []*{{ .PointsFrom.Info.GoName }} ` +
+	"`" + `gorm:"foreignKey:{{ .PointsFromField.GoName }}"` + "`" + `
+	{{- end }}
+	{{- end }}
+	{{- range .Meta.AllOutgoingReferences }}
+	{{- /* All outgoing references are 1-1, so we don't check the .OneToOne flag */}}
+	{{ .GoPointsToFieldName }} *{{ .PointsTo.Info.GoName }}
+	{{- end}}
+}
+func (r *{{ .GoName }}) Scan(ctx context.Context, client *PGClient, rs *sql.Rows) error {
+	client.rwlockFor{{ .GoName }}.RLock()
+	if client.colIdxTabFor{{ .GoName }} == nil {
+		client.rwlockFor{{ .GoName }}.RUnlock() // release the lock to allow the write lock to be aquired
+		err := client.fillColPosTab(
+			ctx,
+			genTimeColIdxTabFor{{ .GoName }},
+			&client.rwlockFor{{ .GoName }},
+			rs,
+			&client.colIdxTabFor{{ .GoName }},
+		)
+		if err != nil {
+			return err
+		}
+		client.rwlockFor{{ .GoName }}.RLock() // get the lock back for the rest of the routine
+	}
+
+	var nullableTgts nullableScanTgtsFor{{ .GoName }}
+
+	scanTgts := make([]interface{}, len(client.colIdxTabFor{{ .GoName }}))
+	for runIdx, genIdx := range client.colIdxTabFor{{ .GoName }} {
+		if genIdx == -1 {
+			scanTgts[runIdx] = &pggenSinkScanner{}
+		} else {
+			scanTgts[runIdx] = scannerTabFor{{ .GoName }}[genIdx](r, &nullableTgts)
+		}
+	}
+	client.rwlockFor{{ .GoName }}.RUnlock() // we are now done referencing the idx tab in the happy path
+
+	err := rs.Scan(scanTgts...)
+	if err != nil {
+		// The database schema may have been changed out from under us, let's
+		// check to see if we just need to update our column index tables and retry.
+		colNames, colsErr := rs.Columns()
+		if colsErr != nil {
+			return fmt.Errorf("pggen: checking column names: %s", colsErr.Error())
+		}
+		client.rwlockFor{{ .GoName }}.RLock()
+		if len(client.colIdxTabFor{{ .GoName }}) != len(colNames) {
+			client.rwlockFor{{ .GoName }}.RUnlock() // release the lock to allow the write lock to be aquired
+			err = client.fillColPosTab(
+				ctx,
+				genTimeColIdxTabFor{{ .GoName }},
+				&client.rwlockFor{{ .GoName }},
+				rs,
+				&client.colIdxTabFor{{ .GoName }},
+			)
+			if err != nil {
+				return err
+			}
+
+			return r.Scan(ctx, client, rs)
+		} else {
+			client.rwlockFor{{ .GoName }}.RUnlock()
+			return err
+		}
+	}
+
+	{{- range .Meta.Info.Cols }}
+	{{- if .Nullable }}
+	r.{{ .GoName }} = {{ call .TypeInfo.NullConvertFunc (printf "nullableTgts.scan%s" .GoName) }}
+	{{- else if (eq .TypeInfo.Name "time.Time") }}
+	r.{{ .GoName }} = {{ printf "nullableTgts.scan%s" .GoName }}.Time
+	{{- end }}
+	{{- end }}
+
+	return nil
+}
+
+type nullableScanTgtsFor{{ .GoName }} struct {
+	{{- range .Meta.Info.Cols }}
+	{{- if (or .Nullable (eq .TypeInfo.Name "time.Time")) }}
+	scan{{ .GoName }} {{ .TypeInfo.ScanNullName }}
+	{{- end }}
+	{{- end }}
+}
+
+// a table mapping codegen-time col indicies to functions returning a scanner for the
+// field that was at that column index at codegen-time.
+var scannerTabFor{{ .GoName }} = [...]func(*{{ .GoName }}, *nullableScanTgtsFor{{ .GoName }}) interface{} {
+	{{- range .Meta.Info.Cols }}
+	func (
+		r *{{ $.GoName }},
+		nullableTgts *nullableScanTgtsFor{{ $.GoName }},
+	) interface{} {
+		{{- if (or .Nullable (eq .TypeInfo.Name "time.Time")) }}
+		return {{ call .TypeInfo.NullSqlReceiver (printf "nullableTgts.scan%s" .GoName) }}
+		{{- else }}
+		return {{ call .TypeInfo.SqlReceiver (printf "r.%s" .GoName) }}
+		{{- end }}
+	},
+	{{- end }}
+}
+
+var genTimeColIdxTabFor{{ .GoName }} map[string]int = map[string]int{
+	{{- range $i, $col := .Meta.Info.Cols }}
+	` + "`" + `{{ $col.PgName }}` + "`" + `: {{ $i }},
+	{{- end }}
+}
+`))


### PR DESCRIPTION
This patch consolidates the code for generating
model structs and query return value structs. This
is nice from a maintanence perspective, but it
also brings a few bugfixes that were only in the
model struct version over to the query version.

In particular, queries of the form `SELECT * FROM ...`
were still vulnerable to schema changes shifting
causing trouble due to gentime vs runtime differences
or migrations run while a service was running.

Closes #121