### PR TITLE
add support for non-public schemas

### DIFF
--- a/cmd/pggen/test/cli_test.go
+++ b/cmd/pggen/test/cli_test.go
@@ -282,6 +282,14 @@ name = "small_entities"
 		exitCode: 0,
 		stderrRE: "WARN: table 'small_entities' has no nullable 'deleted_at' deleted at timestamp",
 	},
+	{
+		toml: `
+[[table]]
+	name = 'badschema."name'
+		`,
+		exitCode: 1,
+		stderrRE: `parsing 'badschema."name': unmatched quote`,
+	},
 }
 
 func TestCLI(t *testing.T) {

--- a/cmd/pggen/test/gorm_compat_test.go
+++ b/cmd/pggen/test/gorm_compat_test.go
@@ -107,7 +107,7 @@ func Test1ToManyForeignKey(t *testing.T) {
 	chkErr(t, err)
 
 	if len(roots[0].WackyAttachments) != 2 {
-		log.Fatal("wrong number of attachments loaded")
+		t.Fatal("wrong number of attachments loaded")
 	}
 }
 
@@ -129,7 +129,7 @@ func Test1To1ForeignKey(t *testing.T) {
 	chkErr(t, err)
 
 	if roots[0].WackySingleAttachment == nil {
-		log.Fatal("failed to load single attachemnt")
+		t.Fatal("failed to load single attachemnt")
 	}
 }
 

--- a/cmd/pggen/test/models/pggen.toml
+++ b/cmd/pggen/test/models/pggen.toml
@@ -1,3 +1,9 @@
+####################################################################################
+#                                                                                  #
+#                                       public                                     #
+#                                                                                  #
+####################################################################################
+
 #
 # Stored Functions
 #
@@ -434,3 +440,43 @@
 
 [[table]]
     name = "offset_table_fillings"
+
+####################################################################################
+#                                                                                  #
+#                                     otherschema                                  #
+#                                                                                  #
+####################################################################################
+
+# stuff for the basic smoke test
+[[table]]
+    name = "otherschema.foos"
+[[stored_function]]
+    name = "otherschema.my_get_foos_value"
+[[statement]]
+    name = "ClobberAllOtherschemaFooValues"
+    body = "UPDATE otherschema.foos SET value = ''"
+[[query]]
+    name = "GetAllOtherschemaFoos"
+    return_type = "Otherschema_Foo"
+    body = "SELECT * FROM otherschema.foos"
+
+# for associations within a non-public schema
+[[table]]
+    name = "otherschema.parents"
+[[table]]
+    name = "otherschema.children"
+[[table]]
+    name = "otherschema.unconstrained_children"
+    [[table.belongs_to]]
+        table = "otherschema.parents"
+        key_field = "parent_id"
+        one_to_one = true # just to mix things up
+
+# for associations between schemas
+[[table]]
+    name = "otherschema.small_entity_children"
+[[table]]
+    name = "children_of_otherschema"
+
+[[table]]
+    name = 'otherschema."funky ""name"'

--- a/cmd/pggen/test/otherschema_test.go
+++ b/cmd/pggen/test/otherschema_test.go
@@ -1,0 +1,201 @@
+package test
+
+import (
+	"testing"
+
+	"github.com/opendoor-labs/pggen"
+	"github.com/opendoor-labs/pggen/cmd/pggen/test/models"
+)
+
+// file: otherschema_test.go
+// This file contains tests to ensure that `pggen` behaves reasonably when pointed at
+// objects not in the 'public' schema.
+
+// TestTestOtherschemaFoos is a smoke test for making sure that a table in a
+// non-public schema works reasonably.
+func TestOtherschemaFoos(t *testing.T) {
+	txClient, err := pgClient.BeginTx(ctx, nil)
+	chkErr(t, err)
+	defer func() {
+		_ = txClient.Rollback()
+	}()
+
+	// insert
+	id, err := txClient.InsertOtherschema_Foo(ctx, &models.Otherschema_Foo{
+		Value:  "a value",
+		MyEnum: models.Otherschema_EnumTypeOpt3,
+	})
+	chkErr(t, err)
+
+	// get (and list transitivly as well)
+	foo, err := txClient.GetOtherschema_Foo(ctx, id)
+	chkErr(t, err)
+	if foo.Value != "a value" {
+		t.Fatal("expected a value")
+	}
+	if foo.MyEnum.String() != "opt3" {
+		t.Fatal("expected opt3")
+	}
+
+	// update
+	_, err = txClient.UpdateOtherschema_Foo(ctx, &models.Otherschema_Foo{
+		Id:    id,
+		Value: "blah",
+	}, models.Otherschema_FooAllFields)
+	chkErr(t, err)
+	foo, err = txClient.GetOtherschema_Foo(ctx, id)
+	chkErr(t, err)
+	if foo.Value != "blah" {
+		t.Fatal("expected blah (1)")
+	}
+
+	// query
+	foos, err := txClient.GetAllOtherschemaFoos(ctx)
+	chkErr(t, err)
+	if len(foos) != 1 {
+		t.Fatal("expected 1 result")
+	}
+	if foos[0].Value != "blah" {
+		t.Fatal("expected blah (2)")
+	}
+
+	// stmt
+	_, err = txClient.ClobberAllOtherschemaFooValues(ctx)
+	chkErr(t, err)
+	foo, err = txClient.GetOtherschema_Foo(ctx, id)
+	chkErr(t, err)
+	if foo.Value != "" {
+		t.Fatal("expected blank")
+	}
+
+	// delete
+	err = txClient.DeleteOtherschema_Foo(ctx, id)
+	chkErr(t, err)
+	_, err = txClient.GetOtherschema_Foo(ctx, id)
+	if !pggen.IsNotFoundError(err) {
+		t.Fatal("expected not found")
+	}
+}
+
+// this tests association support for associations between tables within the same schema
+func TestOtherschemaInternalAssociations(t *testing.T) {
+	txClient, err := pgClient.BeginTx(ctx, nil)
+	chkErr(t, err)
+	defer func() {
+		_ = txClient.Rollback()
+	}()
+
+	parentID, err := txClient.InsertOtherschema_Parent(ctx, &models.Otherschema_Parent{
+		Value: "parent",
+	})
+	chkErr(t, err)
+
+	childID, err := txClient.InsertOtherschema_Child(ctx, &models.Otherschema_Child{
+		Value:    "child",
+		ParentId: parentID,
+	})
+	chkErr(t, err)
+
+	unconstrainedChildID, err := txClient.InsertOtherschema_UnconstrainedChild(ctx, &models.Otherschema_UnconstrainedChild{
+		Value:    "unconstrained_child",
+		ParentId: parentID,
+	})
+	chkErr(t, err)
+
+	// fill from parent to child
+	parent, err := txClient.GetOtherschema_Parent(ctx, parentID)
+	chkErr(t, err)
+	err = txClient.Otherschema_ParentFillIncludes(ctx, parent, models.Otherschema_ParentAllIncludes)
+	chkErr(t, err)
+	if parent.Otherschema_Children[0].Value != "child" {
+		t.Fatal("expected child")
+	}
+	if parent.Otherschema_UnconstrainedChild.Value != "unconstrained_child" {
+		t.Fatal("expected unconstrained_child")
+	}
+
+	// fill in the child
+	child, err := txClient.GetOtherschema_Child(ctx, childID)
+	chkErr(t, err)
+	err = txClient.Otherschema_ChildFillIncludes(ctx, child, models.Otherschema_ChildAllIncludes)
+	chkErr(t, err)
+	if child.Otherschema_Parent.Value != "parent" {
+		t.Fatal("expected parent (child)")
+	}
+
+	// fill in the unconstrained_child
+	unconstrainedChild, err := txClient.GetOtherschema_UnconstrainedChild(ctx, unconstrainedChildID)
+	chkErr(t, err)
+	err = txClient.Otherschema_UnconstrainedChildFillIncludes(ctx, unconstrainedChild, models.Otherschema_UnconstrainedChildAllIncludes)
+	chkErr(t, err)
+	if unconstrainedChild.Otherschema_Parent.Value != "parent" {
+		t.Fatal("expected parent (unconstrained_child)")
+	}
+}
+
+func TestOtherschemaCrossSchemaAssociations(t *testing.T) {
+	txClient, err := pgClient.BeginTx(ctx, nil)
+	chkErr(t, err)
+	defer func() {
+		_ = txClient.Rollback()
+	}()
+
+	// child is in non-public schema
+	smallEntityID, err := txClient.InsertSmallEntity(ctx, &models.SmallEntity{
+		Anint: 9,
+	})
+	chkErr(t, err)
+	childID, err := txClient.InsertOtherschema_SmallEntityChild(ctx, &models.Otherschema_SmallEntityChild{
+		Value:         "small_entity_child",
+		SmallEntityId: smallEntityID,
+	})
+	chkErr(t, err)
+
+	child, err := txClient.GetOtherschema_SmallEntityChild(ctx, childID)
+	chkErr(t, err)
+	err = txClient.Otherschema_SmallEntityChildFillIncludes(ctx, child, models.Otherschema_SmallEntityChildAllIncludes)
+	chkErr(t, err)
+	if child.SmallEntity.Anint != 9 {
+		t.Fatal("expected 9")
+	}
+
+	// child is in public schema
+	parentID, err := txClient.InsertOtherschema_Parent(ctx, &models.Otherschema_Parent{
+		Value: "parent",
+	})
+	chkErr(t, err)
+	childOfOtherschemaID, err := txClient.InsertChildrenOfOtherschema(ctx, &models.ChildrenOfOtherschema{
+		Value:               "children_of_otherschema",
+		OtherschemaParentId: parentID,
+	})
+	chkErr(t, err)
+
+	childOfOtherschema, err := txClient.GetChildrenOfOtherschema(ctx, childOfOtherschemaID)
+	chkErr(t, err)
+	err = txClient.ChildrenOfOtherschemaFillIncludes(ctx, childOfOtherschema, models.ChildrenOfOtherschemaAllIncludes)
+	chkErr(t, err)
+	if childOfOtherschema.Otherschema_Parent.Value != "parent" {
+		t.Fatal("expected parent")
+	}
+}
+
+func TestOtherschemaFunkyName(t *testing.T) {
+	txClient, err := pgClient.BeginTx(ctx, nil)
+	chkErr(t, err)
+	defer func() {
+		_ = txClient.Rollback()
+	}()
+
+	// insert
+	id, err := txClient.InsertOtherschema_Funkyname(ctx, &models.Otherschema_Funkyname{
+		Value: "a value",
+	})
+	chkErr(t, err)
+
+	// get (and list transitivly as well)
+	funky, err := txClient.GetOtherschema_Funkyname(ctx, id)
+	chkErr(t, err)
+	if funky.Value != "a value" {
+		t.Fatal("expected a value")
+	}
+}

--- a/cmd/pggen/test/tables_test.go
+++ b/cmd/pggen/test/tables_test.go
@@ -319,7 +319,7 @@ func TestFillIncludes(t *testing.T) {
 	if smallEntity.SingleAttachment.Id != singleAttachmentID {
 		t.Fatalf("failed to fetch single attachment")
 	}
-	if smallEntity.ExplicitBelongsTo != nil || smallEntity.ExplicitBelongsToMany != nil {
+	if smallEntity.ExplicitBelongsTo != nil || smallEntity.ExplicitBelongsToManies != nil {
 		t.Fatalf("shouldn't load ExplicitBelongsTo or ExplicitBelongsToMany")
 	}
 }
@@ -424,9 +424,9 @@ func TestExplicitBelongsTo(t *testing.T) {
 func TestExplicitBelongsToMany(t *testing.T) {
 	smallEntityType := reflect.TypeOf(models.SmallEntity{})
 
-	f, has := smallEntityType.FieldByName("ExplicitBelongsToMany")
+	f, has := smallEntityType.FieldByName("ExplicitBelongsToManies")
 	if !has {
-		t.Fatalf("pggen generated failed to generate ExplicitBelongsToMany")
+		t.Fatalf("pggen generated failed to generate ExplicitBelongsToManies")
 	}
 
 	if f.Type.Kind() != reflect.Slice {

--- a/examples/extending_models/models/models.gen.go
+++ b/examples/extending_models/models/models.gen.go
@@ -149,7 +149,7 @@ func (p *pgClientImpl) listDog(
 
 	rows, err := p.db.QueryContext(
 		ctx,
-		"SELECT * FROM \"dogs\" WHERE \"id\" = ANY($1)",
+		`SELECT * FROM dogs WHERE "id" = ANY($1)`,
 		pq.Array(ids),
 	)
 	if err != nil {
@@ -287,7 +287,7 @@ func (p *pgClientImpl) bulkInsertDog(
 	}
 
 	bulkInsertQuery := genBulkInsertStmt(
-		"dogs",
+		`dogs`,
 		fieldsForDog,
 		len(values),
 		"id",
@@ -367,12 +367,12 @@ func (p *pgClientImpl) updateDog(
 	opts ...pggen.UpdateOpt,
 ) (ret int64, err error) {
 	if !fieldMask.Test(DogIdFieldIndex) {
-		err = fmt.Errorf("primary key required for updates to 'dogs'")
+		err = fmt.Errorf(`primary key required for updates to 'dogs'`)
 		return
 	}
 
 	updateStmt := genUpdateStmt(
-		"dogs",
+		`dogs`,
 		"id",
 		fieldsForDog,
 		fieldMask,
@@ -633,7 +633,7 @@ func (p *pgClientImpl) bulkDeleteDog(
 	}
 	res, err := p.db.ExecContext(
 		ctx,
-		"DELETE FROM \"dogs\" WHERE \"id\" = ANY($1)",
+		`DELETE FROM dogs WHERE "id" = ANY($1)`,
 		pq.Array(ids),
 	)
 	if err != nil {
@@ -712,7 +712,7 @@ func (p *pgClientImpl) implDogBulkFillIncludes(
 ) (err error) {
 	if includes.TableName != `dogs` {
 		return fmt.Errorf(
-			"expected includes for 'dogs', got '%s'",
+			`expected includes for 'dogs', got '%s'`,
 			includes.TableName,
 		)
 	}

--- a/examples/extending_models/models/pggen_prelude.gen.go
+++ b/examples/extending_models/models/pggen_prelude.gen.go
@@ -42,9 +42,9 @@ func genInsertCommon(
 	pkeyName string,
 	includeID bool,
 ) {
-	into.WriteString("INSERT INTO \"")
+	into.WriteString("INSERT INTO ")
 	into.WriteString(table)
-	into.WriteString("\" (")
+	into.WriteString(" (")
 	for i, field := range fields {
 		if !includeID && field == pkeyName {
 			continue
@@ -93,9 +93,9 @@ func genUpdateStmt(
 ) string {
 	var ret strings.Builder
 
-	ret.WriteString("UPDATE \"")
+	ret.WriteString("UPDATE ")
 	ret.WriteString(table)
-	ret.WriteString("\" SET ")
+	ret.WriteString(" SET ")
 
 	lhs := make([]string, 0, len(fields))
 	rhs := make([]string, 0, len(fields))

--- a/examples/id_in_set/models/models.gen.go
+++ b/examples/id_in_set/models/models.gen.go
@@ -150,7 +150,7 @@ func (p *pgClientImpl) listFoo(
 
 	rows, err := p.db.QueryContext(
 		ctx,
-		"SELECT * FROM \"foos\" WHERE \"id\" = ANY($1)",
+		`SELECT * FROM foos WHERE "id" = ANY($1)`,
 		pq.Array(ids),
 	)
 	if err != nil {
@@ -286,7 +286,7 @@ func (p *pgClientImpl) bulkInsertFoo(
 	}
 
 	bulkInsertQuery := genBulkInsertStmt(
-		"foos",
+		`foos`,
 		fieldsForFoo,
 		len(values),
 		"id",
@@ -362,12 +362,12 @@ func (p *pgClientImpl) updateFoo(
 	opts ...pggen.UpdateOpt,
 ) (ret int64, err error) {
 	if !fieldMask.Test(FooIdFieldIndex) {
-		err = fmt.Errorf("primary key required for updates to 'foos'")
+		err = fmt.Errorf(`primary key required for updates to 'foos'`)
 		return
 	}
 
 	updateStmt := genUpdateStmt(
-		"foos",
+		`foos`,
 		"id",
 		fieldsForFoo,
 		fieldMask,
@@ -612,7 +612,7 @@ func (p *pgClientImpl) bulkDeleteFoo(
 	}
 	res, err := p.db.ExecContext(
 		ctx,
-		"DELETE FROM \"foos\" WHERE \"id\" = ANY($1)",
+		`DELETE FROM foos WHERE "id" = ANY($1)`,
 		pq.Array(ids),
 	)
 	if err != nil {
@@ -691,7 +691,7 @@ func (p *pgClientImpl) implFooBulkFillIncludes(
 ) (err error) {
 	if includes.TableName != `foos` {
 		return fmt.Errorf(
-			"expected includes for 'foos', got '%s'",
+			`expected includes for 'foos', got '%s'`,
 			includes.TableName,
 		)
 	}

--- a/examples/id_in_set/models/pggen_prelude.gen.go
+++ b/examples/id_in_set/models/pggen_prelude.gen.go
@@ -42,9 +42,9 @@ func genInsertCommon(
 	pkeyName string,
 	includeID bool,
 ) {
-	into.WriteString("INSERT INTO \"")
+	into.WriteString("INSERT INTO ")
 	into.WriteString(table)
-	into.WriteString("\" (")
+	into.WriteString(" (")
 	for i, field := range fields {
 		if !includeID && field == pkeyName {
 			continue
@@ -93,9 +93,9 @@ func genUpdateStmt(
 ) string {
 	var ret strings.Builder
 
-	ret.WriteString("UPDATE \"")
+	ret.WriteString("UPDATE ")
 	ret.WriteString(table)
-	ret.WriteString("\" SET ")
+	ret.WriteString(" SET ")
 
 	lhs := make([]string, 0, len(fields))
 	rhs := make([]string, 0, len(fields))

--- a/examples/include_specs/models/models.gen.go
+++ b/examples/include_specs/models/models.gen.go
@@ -152,7 +152,7 @@ func (p *pgClientImpl) listGrandparent(
 
 	rows, err := p.db.QueryContext(
 		ctx,
-		"SELECT * FROM \"grandparents\" WHERE \"id\" = ANY($1)",
+		`SELECT * FROM grandparents WHERE "id" = ANY($1)`,
 		pq.Array(ids),
 	)
 	if err != nil {
@@ -289,7 +289,7 @@ func (p *pgClientImpl) bulkInsertGrandparent(
 	}
 
 	bulkInsertQuery := genBulkInsertStmt(
-		"grandparents",
+		`grandparents`,
 		fieldsForGrandparent,
 		len(values),
 		"id",
@@ -367,12 +367,12 @@ func (p *pgClientImpl) updateGrandparent(
 	opts ...pggen.UpdateOpt,
 ) (ret int64, err error) {
 	if !fieldMask.Test(GrandparentIdFieldIndex) {
-		err = fmt.Errorf("primary key required for updates to 'grandparents'")
+		err = fmt.Errorf(`primary key required for updates to 'grandparents'`)
 		return
 	}
 
 	updateStmt := genUpdateStmt(
-		"grandparents",
+		`grandparents`,
 		"id",
 		fieldsForGrandparent,
 		fieldMask,
@@ -625,7 +625,7 @@ func (p *pgClientImpl) bulkDeleteGrandparent(
 	}
 	res, err := p.db.ExecContext(
 		ctx,
-		"DELETE FROM \"grandparents\" WHERE \"id\" = ANY($1)",
+		`DELETE FROM grandparents WHERE "id" = ANY($1)`,
 		pq.Array(ids),
 	)
 	if err != nil {
@@ -704,7 +704,7 @@ func (p *pgClientImpl) implGrandparentBulkFillIncludes(
 ) (err error) {
 	if includes.TableName != `grandparents` {
 		return fmt.Errorf(
-			"expected includes for 'grandparents', got '%s'",
+			`expected includes for 'grandparents', got '%s'`,
 			includes.TableName,
 		)
 	}
@@ -796,7 +796,7 @@ func (p *pgClientImpl) privateGrandparentFillParents(
 
 	rows, err := p.db.QueryContext(
 		ctx,
-		`SELECT * FROM "parents"
+		`SELECT * FROM parents
 		 WHERE "grandparent_id" = ANY($1)
 		 `,
 		pq.Array(ids),
@@ -894,8 +894,8 @@ func (p *pgClientImpl) privateGrandparentFillParentFavoriteGrandkid(
 	if len(ids) > 0 {
 		rows, err := p.db.QueryContext(
 			ctx,
-			`SELECT * FROM "children"
-			WHERE "id" = ANY($1)`,
+			`SELECT * FROM children
+			WHERE id = ANY($1)`,
 			pq.Array(ids),
 		)
 		if err != nil {
@@ -978,7 +978,7 @@ func (p *pgClientImpl) listParent(
 
 	rows, err := p.db.QueryContext(
 		ctx,
-		"SELECT * FROM \"parents\" WHERE \"id\" = ANY($1)",
+		`SELECT * FROM parents WHERE "id" = ANY($1)`,
 		pq.Array(ids),
 	)
 	if err != nil {
@@ -1115,7 +1115,7 @@ func (p *pgClientImpl) bulkInsertParent(
 	}
 
 	bulkInsertQuery := genBulkInsertStmt(
-		"parents",
+		`parents`,
 		fieldsForParent,
 		len(values),
 		"id",
@@ -1193,12 +1193,12 @@ func (p *pgClientImpl) updateParent(
 	opts ...pggen.UpdateOpt,
 ) (ret int64, err error) {
 	if !fieldMask.Test(ParentIdFieldIndex) {
-		err = fmt.Errorf("primary key required for updates to 'parents'")
+		err = fmt.Errorf(`primary key required for updates to 'parents'`)
 		return
 	}
 
 	updateStmt := genUpdateStmt(
-		"parents",
+		`parents`,
 		"id",
 		fieldsForParent,
 		fieldMask,
@@ -1451,7 +1451,7 @@ func (p *pgClientImpl) bulkDeleteParent(
 	}
 	res, err := p.db.ExecContext(
 		ctx,
-		"DELETE FROM \"parents\" WHERE \"id\" = ANY($1)",
+		`DELETE FROM parents WHERE "id" = ANY($1)`,
 		pq.Array(ids),
 	)
 	if err != nil {
@@ -1530,7 +1530,7 @@ func (p *pgClientImpl) implParentBulkFillIncludes(
 ) (err error) {
 	if includes.TableName != `parents` {
 		return fmt.Errorf(
-			"expected includes for 'parents', got '%s'",
+			`expected includes for 'parents', got '%s'`,
 			includes.TableName,
 		)
 	}
@@ -1622,7 +1622,7 @@ func (p *pgClientImpl) privateParentFillChildren(
 
 	rows, err := p.db.QueryContext(
 		ctx,
-		`SELECT * FROM "children"
+		`SELECT * FROM children
 		 WHERE "parent_id" = ANY($1)
 		 `,
 		pq.Array(ids),
@@ -1714,8 +1714,8 @@ func (p *pgClientImpl) privateParentFillParentGrandparent(
 	if len(ids) > 0 {
 		rows, err := p.db.QueryContext(
 			ctx,
-			`SELECT * FROM "grandparents"
-			WHERE "id" = ANY($1)`,
+			`SELECT * FROM grandparents
+			WHERE id = ANY($1)`,
 			pq.Array(ids),
 		)
 		if err != nil {
@@ -1798,7 +1798,7 @@ func (p *pgClientImpl) listChild(
 
 	rows, err := p.db.QueryContext(
 		ctx,
-		"SELECT * FROM \"children\" WHERE \"id\" = ANY($1)",
+		`SELECT * FROM children WHERE "id" = ANY($1)`,
 		pq.Array(ids),
 	)
 	if err != nil {
@@ -1935,7 +1935,7 @@ func (p *pgClientImpl) bulkInsertChild(
 	}
 
 	bulkInsertQuery := genBulkInsertStmt(
-		"children",
+		`children`,
 		fieldsForChild,
 		len(values),
 		"id",
@@ -2013,12 +2013,12 @@ func (p *pgClientImpl) updateChild(
 	opts ...pggen.UpdateOpt,
 ) (ret int64, err error) {
 	if !fieldMask.Test(ChildIdFieldIndex) {
-		err = fmt.Errorf("primary key required for updates to 'children'")
+		err = fmt.Errorf(`primary key required for updates to 'children'`)
 		return
 	}
 
 	updateStmt := genUpdateStmt(
-		"children",
+		`children`,
 		"id",
 		fieldsForChild,
 		fieldMask,
@@ -2271,7 +2271,7 @@ func (p *pgClientImpl) bulkDeleteChild(
 	}
 	res, err := p.db.ExecContext(
 		ctx,
-		"DELETE FROM \"children\" WHERE \"id\" = ANY($1)",
+		`DELETE FROM children WHERE "id" = ANY($1)`,
 		pq.Array(ids),
 	)
 	if err != nil {
@@ -2350,7 +2350,7 @@ func (p *pgClientImpl) implChildBulkFillIncludes(
 ) (err error) {
 	if includes.TableName != `children` {
 		return fmt.Errorf(
-			"expected includes for 'children', got '%s'",
+			`expected includes for 'children', got '%s'`,
 			includes.TableName,
 		)
 	}
@@ -2445,7 +2445,7 @@ func (p *pgClientImpl) privateChildFillDarlingGrandparents(
 
 	rows, err := p.db.QueryContext(
 		ctx,
-		`SELECT * FROM "grandparents"
+		`SELECT * FROM grandparents
 		 WHERE "favorite_grandkid_id" = ANY($1)
 		 `,
 		pq.Array(ids),
@@ -2538,8 +2538,8 @@ func (p *pgClientImpl) privateChildFillParentParent(
 	if len(ids) > 0 {
 		rows, err := p.db.QueryContext(
 			ctx,
-			`SELECT * FROM "parents"
-			WHERE "id" = ANY($1)`,
+			`SELECT * FROM parents
+			WHERE id = ANY($1)`,
 			pq.Array(ids),
 		)
 		if err != nil {

--- a/examples/include_specs/models/pggen_prelude.gen.go
+++ b/examples/include_specs/models/pggen_prelude.gen.go
@@ -42,9 +42,9 @@ func genInsertCommon(
 	pkeyName string,
 	includeID bool,
 ) {
-	into.WriteString("INSERT INTO \"")
+	into.WriteString("INSERT INTO ")
 	into.WriteString(table)
-	into.WriteString("\" (")
+	into.WriteString(" (")
 	for i, field := range fields {
 		if !includeID && field == pkeyName {
 			continue
@@ -93,9 +93,9 @@ func genUpdateStmt(
 ) string {
 	var ret strings.Builder
 
-	ret.WriteString("UPDATE \"")
+	ret.WriteString("UPDATE ")
 	ret.WriteString(table)
-	ret.WriteString("\" SET ")
+	ret.WriteString(" SET ")
 
 	lhs := make([]string, 0, len(fields))
 	rhs := make([]string, 0, len(fields))

--- a/examples/middleware/models/models.gen.go
+++ b/examples/middleware/models/models.gen.go
@@ -148,7 +148,7 @@ func (p *pgClientImpl) listFoo(
 
 	rows, err := p.db.QueryContext(
 		ctx,
-		"SELECT * FROM \"foos\" WHERE \"id\" = ANY($1)",
+		`SELECT * FROM foos WHERE "id" = ANY($1)`,
 		pq.Array(ids),
 	)
 	if err != nil {
@@ -284,7 +284,7 @@ func (p *pgClientImpl) bulkInsertFoo(
 	}
 
 	bulkInsertQuery := genBulkInsertStmt(
-		"foos",
+		`foos`,
 		fieldsForFoo,
 		len(values),
 		"id",
@@ -360,12 +360,12 @@ func (p *pgClientImpl) updateFoo(
 	opts ...pggen.UpdateOpt,
 ) (ret int64, err error) {
 	if !fieldMask.Test(FooIdFieldIndex) {
-		err = fmt.Errorf("primary key required for updates to 'foos'")
+		err = fmt.Errorf(`primary key required for updates to 'foos'`)
 		return
 	}
 
 	updateStmt := genUpdateStmt(
-		"foos",
+		`foos`,
 		"id",
 		fieldsForFoo,
 		fieldMask,
@@ -610,7 +610,7 @@ func (p *pgClientImpl) bulkDeleteFoo(
 	}
 	res, err := p.db.ExecContext(
 		ctx,
-		"DELETE FROM \"foos\" WHERE \"id\" = ANY($1)",
+		`DELETE FROM foos WHERE "id" = ANY($1)`,
 		pq.Array(ids),
 	)
 	if err != nil {
@@ -689,7 +689,7 @@ func (p *pgClientImpl) implFooBulkFillIncludes(
 ) (err error) {
 	if includes.TableName != `foos` {
 		return fmt.Errorf(
-			"expected includes for 'foos', got '%s'",
+			`expected includes for 'foos', got '%s'`,
 			includes.TableName,
 		)
 	}

--- a/examples/middleware/models/pggen_prelude.gen.go
+++ b/examples/middleware/models/pggen_prelude.gen.go
@@ -42,9 +42,9 @@ func genInsertCommon(
 	pkeyName string,
 	includeID bool,
 ) {
-	into.WriteString("INSERT INTO \"")
+	into.WriteString("INSERT INTO ")
 	into.WriteString(table)
-	into.WriteString("\" (")
+	into.WriteString(" (")
 	for i, field := range fields {
 		if !includeID && field == pkeyName {
 			continue
@@ -93,9 +93,9 @@ func genUpdateStmt(
 ) string {
 	var ret strings.Builder
 
-	ret.WriteString("UPDATE \"")
+	ret.WriteString("UPDATE ")
 	ret.WriteString(table)
-	ret.WriteString("\" SET ")
+	ret.WriteString(" SET ")
 
 	lhs := make([]string, 0, len(fields))
 	rhs := make([]string, 0, len(fields))

--- a/examples/middleware/output.txt
+++ b/examples/middleware/output.txt
@@ -1,11 +1,11 @@
-QueryContext query: INSERT INTO "foos" ("value") VALUES ($1)
+QueryContext query: INSERT INTO foos ("value") VALUES ($1)
  RETURNING "id"
-QueryContext query: INSERT INTO "foos" ("value") VALUES ($1)
+QueryContext query: INSERT INTO foos ("value") VALUES ($1)
  RETURNING "id"
-QueryContext query: INSERT INTO "foos" ("value") VALUES ($1)
+QueryContext query: INSERT INTO foos ("value") VALUES ($1)
  RETURNING "id"
-QueryRowContext query: UPDATE "foos" SET ("id","value") = ($1, $2) WHERE "id" = $3 RETURNING "id"
-ExecContext query: DELETE FROM "foos" WHERE "id" = ANY($1)
-QueryContext query: SELECT * FROM "foos" WHERE "id" = ANY($1)
+QueryRowContext query: UPDATE foos SET ("id","value") = ($1, $2) WHERE "id" = $3 RETURNING "id"
+ExecContext query: DELETE FROM foos WHERE "id" = ANY($1)
+QueryContext query: SELECT * FROM foos WHERE "id" = ANY($1)
 bax
 lish

--- a/examples/query_argument_names/models/models.gen.go
+++ b/examples/query_argument_names/models/models.gen.go
@@ -150,7 +150,7 @@ func (p *pgClientImpl) listUser(
 
 	rows, err := p.db.QueryContext(
 		ctx,
-		"SELECT * FROM \"users\" WHERE \"id\" = ANY($1)",
+		`SELECT * FROM users WHERE "id" = ANY($1)`,
 		pq.Array(ids),
 	)
 	if err != nil {
@@ -287,7 +287,7 @@ func (p *pgClientImpl) bulkInsertUser(
 	}
 
 	bulkInsertQuery := genBulkInsertStmt(
-		"users",
+		`users`,
 		fieldsForUser,
 		len(values),
 		"id",
@@ -365,12 +365,12 @@ func (p *pgClientImpl) updateUser(
 	opts ...pggen.UpdateOpt,
 ) (ret int64, err error) {
 	if !fieldMask.Test(UserIdFieldIndex) {
-		err = fmt.Errorf("primary key required for updates to 'users'")
+		err = fmt.Errorf(`primary key required for updates to 'users'`)
 		return
 	}
 
 	updateStmt := genUpdateStmt(
-		"users",
+		`users`,
 		"id",
 		fieldsForUser,
 		fieldMask,
@@ -623,7 +623,7 @@ func (p *pgClientImpl) bulkDeleteUser(
 	}
 	res, err := p.db.ExecContext(
 		ctx,
-		"DELETE FROM \"users\" WHERE \"id\" = ANY($1)",
+		`DELETE FROM users WHERE "id" = ANY($1)`,
 		pq.Array(ids),
 	)
 	if err != nil {
@@ -702,7 +702,7 @@ func (p *pgClientImpl) implUserBulkFillIncludes(
 ) (err error) {
 	if includes.TableName != `users` {
 		return fmt.Errorf(
-			"expected includes for 'users', got '%s'",
+			`expected includes for 'users', got '%s'`,
 			includes.TableName,
 		)
 	}

--- a/examples/query_argument_names/models/pggen_prelude.gen.go
+++ b/examples/query_argument_names/models/pggen_prelude.gen.go
@@ -42,9 +42,9 @@ func genInsertCommon(
 	pkeyName string,
 	includeID bool,
 ) {
-	into.WriteString("INSERT INTO \"")
+	into.WriteString("INSERT INTO ")
 	into.WriteString(table)
-	into.WriteString("\" (")
+	into.WriteString(" (")
 	for i, field := range fields {
 		if !includeID && field == pkeyName {
 			continue
@@ -93,9 +93,9 @@ func genUpdateStmt(
 ) string {
 	var ret strings.Builder
 
-	ret.WriteString("UPDATE \"")
+	ret.WriteString("UPDATE ")
 	ret.WriteString(table)
-	ret.WriteString("\" SET ")
+	ret.WriteString(" SET ")
 
 	lhs := make([]string, 0, len(fields))
 	rhs := make([]string, 0, len(fields))

--- a/examples/single_results/models/models.gen.go
+++ b/examples/single_results/models/models.gen.go
@@ -150,7 +150,7 @@ func (p *pgClientImpl) listFoo(
 
 	rows, err := p.db.QueryContext(
 		ctx,
-		"SELECT * FROM \"foos\" WHERE \"id\" = ANY($1)",
+		`SELECT * FROM foos WHERE "id" = ANY($1)`,
 		pq.Array(ids),
 	)
 	if err != nil {
@@ -286,7 +286,7 @@ func (p *pgClientImpl) bulkInsertFoo(
 	}
 
 	bulkInsertQuery := genBulkInsertStmt(
-		"foos",
+		`foos`,
 		fieldsForFoo,
 		len(values),
 		"id",
@@ -362,12 +362,12 @@ func (p *pgClientImpl) updateFoo(
 	opts ...pggen.UpdateOpt,
 ) (ret int64, err error) {
 	if !fieldMask.Test(FooIdFieldIndex) {
-		err = fmt.Errorf("primary key required for updates to 'foos'")
+		err = fmt.Errorf(`primary key required for updates to 'foos'`)
 		return
 	}
 
 	updateStmt := genUpdateStmt(
-		"foos",
+		`foos`,
 		"id",
 		fieldsForFoo,
 		fieldMask,
@@ -612,7 +612,7 @@ func (p *pgClientImpl) bulkDeleteFoo(
 	}
 	res, err := p.db.ExecContext(
 		ctx,
-		"DELETE FROM \"foos\" WHERE \"id\" = ANY($1)",
+		`DELETE FROM foos WHERE "id" = ANY($1)`,
 		pq.Array(ids),
 	)
 	if err != nil {
@@ -691,7 +691,7 @@ func (p *pgClientImpl) implFooBulkFillIncludes(
 ) (err error) {
 	if includes.TableName != `foos` {
 		return fmt.Errorf(
-			"expected includes for 'foos', got '%s'",
+			`expected includes for 'foos', got '%s'`,
 			includes.TableName,
 		)
 	}

--- a/examples/single_results/models/pggen_prelude.gen.go
+++ b/examples/single_results/models/pggen_prelude.gen.go
@@ -42,9 +42,9 @@ func genInsertCommon(
 	pkeyName string,
 	includeID bool,
 ) {
-	into.WriteString("INSERT INTO \"")
+	into.WriteString("INSERT INTO ")
 	into.WriteString(table)
-	into.WriteString("\" (")
+	into.WriteString(" (")
 	for i, field := range fields {
 		if !includeID && field == pkeyName {
 			continue
@@ -93,9 +93,9 @@ func genUpdateStmt(
 ) string {
 	var ret strings.Builder
 
-	ret.WriteString("UPDATE \"")
+	ret.WriteString("UPDATE ")
 	ret.WriteString(table)
-	ret.WriteString("\" SET ")
+	ret.WriteString(" SET ")
 
 	lhs := make([]string, 0, len(fields))
 	rhs := make([]string, 0, len(fields))

--- a/examples/timestamps/models/models.gen.go
+++ b/examples/timestamps/models/models.gen.go
@@ -151,7 +151,7 @@ func (p *pgClientImpl) listUser(
 
 	rows, err := p.db.QueryContext(
 		ctx,
-		"SELECT * FROM \"users\" WHERE \"id\" = ANY($1) AND \"deleted_at\" IS NULL ",
+		`SELECT * FROM users WHERE "id" = ANY($1) AND "deleted_at" IS NULL `,
 		pq.Array(ids),
 	)
 	if err != nil {
@@ -299,7 +299,7 @@ func (p *pgClientImpl) bulkInsertUser(
 	}
 
 	bulkInsertQuery := genBulkInsertStmt(
-		"users",
+		`users`,
 		fieldsForUser,
 		len(values),
 		"id",
@@ -381,7 +381,7 @@ func (p *pgClientImpl) updateUser(
 	opts ...pggen.UpdateOpt,
 ) (ret int64, err error) {
 	if !fieldMask.Test(UserIdFieldIndex) {
-		err = fmt.Errorf("primary key required for updates to 'users'")
+		err = fmt.Errorf(`primary key required for updates to 'users'`)
 		return
 	}
 	now := time.Now().UTC()
@@ -389,7 +389,7 @@ func (p *pgClientImpl) updateUser(
 	fieldMask.Set(UserUpdatedAtFieldIndex, true)
 
 	updateStmt := genUpdateStmt(
-		"users",
+		`users`,
 		"id",
 		fieldsForUser,
 		fieldMask,
@@ -675,13 +675,13 @@ func (p *pgClientImpl) bulkDeleteUser(
 	if options.DoHardDelete {
 		res, err = p.db.ExecContext(
 			ctx,
-			"DELETE FROM \"users\" WHERE \"id\" = ANY($1)",
+			`DELETE FROM users WHERE "id" = ANY($1)`,
 			pq.Array(ids),
 		)
 	} else {
 		res, err = p.db.ExecContext(
 			ctx,
-			"UPDATE \"users\" SET \"deleted_at\" = $1 WHERE \"id\" = ANY($2)",
+			`UPDATE users SET "deleted_at" = $1 WHERE "id" = ANY($2)`,
 			now,
 			pq.Array(ids),
 		)
@@ -762,7 +762,7 @@ func (p *pgClientImpl) implUserBulkFillIncludes(
 ) (err error) {
 	if includes.TableName != `users` {
 		return fmt.Errorf(
-			"expected includes for 'users', got '%s'",
+			`expected includes for 'users', got '%s'`,
 			includes.TableName,
 		)
 	}

--- a/examples/timestamps/models/pggen_prelude.gen.go
+++ b/examples/timestamps/models/pggen_prelude.gen.go
@@ -42,9 +42,9 @@ func genInsertCommon(
 	pkeyName string,
 	includeID bool,
 ) {
-	into.WriteString("INSERT INTO \"")
+	into.WriteString("INSERT INTO ")
 	into.WriteString(table)
-	into.WriteString("\" (")
+	into.WriteString(" (")
 	for i, field := range fields {
 		if !includeID && field == pkeyName {
 			continue
@@ -93,9 +93,9 @@ func genUpdateStmt(
 ) string {
 	var ret strings.Builder
 
-	ret.WriteString("UPDATE \"")
+	ret.WriteString("UPDATE ")
 	ret.WriteString(table)
-	ret.WriteString("\" SET ")
+	ret.WriteString(" SET ")
 
 	lhs := make([]string, 0, len(fields))
 	rhs := make([]string, 0, len(fields))

--- a/gen/gen_prelude.go
+++ b/gen/gen_prelude.go
@@ -71,9 +71,9 @@ func genInsertCommon(
 	pkeyName string,
 	includeID bool,
 ) {
-	into.WriteString("INSERT INTO \"")
+	into.WriteString("INSERT INTO ")
 	into.WriteString(table)
-	into.WriteString("\" (")
+	into.WriteString(" (")
 	for i, field := range fields {
 		if !includeID && field == pkeyName {
 			continue
@@ -122,9 +122,9 @@ func genUpdateStmt(
 ) string {
 	var ret strings.Builder
 
-	ret.WriteString("UPDATE \"")
+	ret.WriteString("UPDATE ")
 	ret.WriteString(table)
-	ret.WriteString("\" SET ")
+	ret.WriteString(" SET ")
 
 	lhs := make([]string, 0, len(fields))
 	rhs := make([]string, 0, len(fields))

--- a/gen/internal/names/names.go
+++ b/gen/internal/names/names.go
@@ -15,7 +15,18 @@ import (
 //
 
 func PgTableToGoModel(tableName string) string {
-	return PgToGoName(inflection.Singular(tableName))
+	parsed, err := ParsePgName(tableName)
+	if err != nil {
+		// fall back to treating the name as a single name
+		// not idea, but we want to keep this infallable
+		return PgToGoName(inflection.Singular(tableName))
+	}
+
+	if parsed.Schema == "public" {
+		return PgToGoName(inflection.Singular(parsed.Name))
+	}
+
+	return PgToGoName(parsed.Schema) + "_" + PgToGoName(inflection.Singular(parsed.Name))
 }
 
 // Convert a postgres name (assumed to be snake_case)

--- a/gen/internal/names/names_test.go
+++ b/gen/internal/names/names_test.go
@@ -40,3 +40,28 @@ func TestPgToGoName(t *testing.T) {
 		}
 	}
 }
+
+func TestPgTableToGoModel(t *testing.T) {
+	type testCase struct {
+		src      string
+		expected string
+	}
+
+	cases := []testCase{
+		{
+			src:      "foos",
+			expected: "Foo",
+		},
+		{
+			src:      "foo.bars",
+			expected: "Foo_Bar",
+		},
+	}
+
+	for i, c := range cases {
+		actual := PgTableToGoModel(c.src)
+		if actual != c.expected {
+			t.Fatalf("%d: expected '%s', got '%s'", i, c.expected, actual)
+		}
+	}
+}

--- a/gen/internal/names/parse_pgname.go
+++ b/gen/internal/names/parse_pgname.go
@@ -1,0 +1,125 @@
+package names
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// file: parse_pgname.go
+// This file implements a parser and pretty-printer for postgres names. The main
+// thing that it does is split the schema name out.
+
+// NOTE: copy-pasted from the includes package, but there is no great way
+//       to share between the two packages.
+var unquotedIdentRE = regexp.MustCompile("^[a-zA-Z_][a-zA-Z0-9_$]*$")
+
+// PgName represents an identifier in postgres
+type PgName struct {
+	// The name of the schema. Never blank (always 'public' if no schema is specified).
+	// Not quoted.
+	Schema string
+	// The inner name. Never blank. Not quoted.
+	Name string
+}
+
+// String returns a quoted version of this identifier suitable for use in SQL
+func (p *PgName) String() string {
+	if p.Schema == "public" || p.Schema == "" {
+		return toIdentPart(p.Name)
+	}
+
+	return fmt.Sprintf("%s.%s", toIdentPart(p.Schema), toIdentPart(p.Name))
+}
+
+func toIdentPart(part string) string {
+	if unquotedIdentRE.Match([]byte(part)) {
+		return part
+	}
+
+	return fmt.Sprintf(`"%s"`, strings.ReplaceAll(part, `"`, `""`))
+}
+
+func ParsePgName(input string) (PgName, error) {
+	var res PgName
+
+	parts := strings.Split(input, ".")
+	if len(parts) > 2 {
+		return res, fmt.Errorf("parsing '%s': nested schemas are not supported", input)
+	}
+
+	var (
+		err error
+	)
+	if len(parts) == 1 {
+		res.Name, err = unquoteNamePart(strings.TrimSpace(parts[0]))
+	} else if len(parts) == 2 {
+		res.Schema, err = unquoteNamePart(strings.TrimSpace(parts[0]))
+		if err == nil {
+			res.Name, err = unquoteNamePart(strings.TrimSpace(parts[1]))
+		}
+	}
+	if err != nil {
+		return res, fmt.Errorf("parsing '%s': %s", input, err.Error())
+	}
+	if res.Schema == "" || res.Schema == `""` {
+		res.Schema = "public"
+	}
+
+	return res, nil
+}
+
+func unquoteNamePart(part string) (string, error) {
+	if len(part) == 0 {
+		return "", fmt.Errorf("empty identifier")
+	}
+
+	// short circuit for the common case where there are no quotes
+	if strings.IndexByte(part, '"') == -1 {
+		return part, nil
+	}
+
+	if part[0] != '"' {
+		return "", fmt.Errorf("identifiers cannot begin quoting in the middle")
+	}
+
+	if part[len(part)-1] != '"' || len(part) == 1 {
+		return "", fmt.Errorf("unmatched quote")
+	}
+
+	part = part[1 : len(part)-1]
+	// check again for an empty identifier now that we've trimmed the quotes
+	if len(part) == 0 {
+		return "", fmt.Errorf("empty identifier")
+	}
+
+	// handle escaped quotes, if any
+	quoteIdx := strings.IndexByte(part, '"')
+	if quoteIdx > -1 {
+		var shrunkIdent strings.Builder
+		rest := part
+		for {
+			if quoteIdx+1 >= len(rest) || rest[quoteIdx+1] != '"' {
+				return "", fmt.Errorf("unmatched quote")
+			}
+
+			shrunkIdent.WriteString(rest[0:quoteIdx])
+			shrunkIdent.WriteByte('"')
+			if quoteIdx+2 < len(rest) {
+				rest = rest[quoteIdx+2:]
+			} else {
+				rest = ""
+				break
+			}
+
+			quoteIdx = strings.IndexByte(rest, '"')
+			if quoteIdx == -1 {
+				break
+			}
+		}
+		shrunkIdent.WriteString(rest)
+		part = shrunkIdent.String()
+	}
+
+	return part, nil
+}

--- a/gen/internal/names/parse_pgname_test.go
+++ b/gen/internal/names/parse_pgname_test.go
@@ -1,0 +1,144 @@
+package names
+
+import (
+	"reflect"
+	"regexp"
+	"testing"
+)
+
+func TestPgNameRoundTrip(t *testing.T) {
+	type testCase struct {
+		input string
+		// regex matching error string if non-blank
+		err string
+		// expected output if non-nil
+		out *PgName
+		// expected output of calling .String() if non-blank
+		outString string
+	}
+
+	cases := []testCase{
+		{
+			input:     "foo",
+			out:       &PgName{Schema: "public", Name: "foo"},
+			outString: `foo`,
+		},
+		{
+			input: `foo.bar.baz`,
+			err:   ".*nested schemas are not supported.*",
+		},
+		{
+			input:     `"foo"`,
+			out:       &PgName{Schema: "public", Name: "foo"},
+			outString: `foo`,
+		},
+		{
+			input: `.foo`,
+			err:   "empty identifier",
+		},
+		{
+			input: `foo.`,
+			err:   "empty identifier",
+		},
+		{
+			input: `"".foo`,
+			err:   "empty identifier",
+		},
+		{
+			input: `foo.""`,
+			err:   "empty identifier",
+		},
+		{
+			input: `foo."`,
+			err:   "unmatched quote",
+		},
+		{
+			input: `foo."sdfas`,
+			err:   "unmatched quote",
+		},
+		{
+			input: `"foo.sdfas`,
+			err:   "unmatched quote",
+		},
+		{
+			input: `"foo"."sdfas`,
+			err:   "unmatched quote",
+		},
+		{
+			input: `foo"asdfadsf`,
+			err:   "cannot begin quoting in the middle",
+		},
+		{
+			input:     `"foo".bar`,
+			out:       &PgName{Schema: "foo", Name: "bar"},
+			outString: `foo.bar`,
+		},
+		{
+			input:     `foo.bar`,
+			out:       &PgName{Schema: "foo", Name: "bar"},
+			outString: `foo.bar`,
+		},
+		{
+			input: `foo."b"ar"`,
+			err:   "unmatched quote",
+		},
+		{
+			input:     `foo."b""ar"`,
+			out:       &PgName{Schema: "foo", Name: `b"ar`},
+			outString: `foo."b""ar"`,
+		},
+		{
+			input:     `foo."b""a""r"`,
+			out:       &PgName{Schema: "foo", Name: `b"a"r`},
+			outString: `foo."b""a""r"`,
+		},
+		{
+			input:     `foo."b ar"`,
+			out:       &PgName{Schema: "foo", Name: `b ar`},
+			outString: `foo."b ar"`,
+		},
+		{
+			// Can't have escaped quotes in an unquoted identifier. This is not the best error message,
+			// but it is good enough for government work.
+			input: `f""oo.bar`,
+			err:   "cannot begin quoting in the middle",
+		},
+		{
+			input: `foo.bar.baz`,
+			err:   "nested schemas are not supported",
+		},
+	}
+
+	for i, c := range cases {
+		res, err := ParsePgName(c.input)
+
+		if c.err != "" {
+			if err == nil {
+				t.Fatalf("%d: expected error but there was none", i)
+			} else {
+				matches, reErr := regexp.Match(c.err, []byte(err.Error()))
+				if reErr != nil {
+					t.Fatalf("%d: bad regex: /%s/: %s", i, c.err, reErr.Error())
+				}
+				if !matches {
+					t.Fatalf("%d: /%s/ fails to match err '%s'", i, c.err, err.Error())
+				}
+			}
+		} else if err != nil {
+			t.Fatalf("%d: unexpected error: %s", i, err.Error())
+		}
+
+		if c.out != nil {
+			if !reflect.DeepEqual(c.out, &res) {
+				t.Fatalf("%d: cmp: actual = %#v, expected = %#v", i, res, c.out)
+			}
+		}
+
+		if c.outString != "" {
+			roundTripTxt := res.String()
+			if roundTripTxt != c.outString {
+				t.Fatalf("%d: rt: actual = '%s', expected = '%s'", i, roundTripTxt, c.outString)
+			}
+		}
+	}
+}

--- a/gen/internal/types/gen_struct.go
+++ b/gen/internal/types/gen_struct.go
@@ -26,9 +26,7 @@ func (r *Resolver) EmitStructType(typeName string, genCtx interface{}) error {
 		return err
 	}
 
-	sigTxt := typeSig.String()
-	bodyTxt := typeBody.String()
-	err = r.EmitType(typeName, sigTxt, bodyTxt) //typeSig.String(), typeBody.String())
+	err = r.EmitType(typeName, typeSig.String(), typeBody.String())
 	if err != nil {
 		return err
 	}

--- a/gen/internal/types/types.go
+++ b/gen/internal/types/types.go
@@ -50,6 +50,10 @@ func (r *Resolver) EmitType(name string, sig string, body string) error {
 	return r.types.emitType(name, sig, body)
 }
 
+func (r *Resolver) Probe(name string) bool {
+	return r.types.probe(name)
+}
+
 type Info struct {
 	// The Name of the type
 	Name string
@@ -435,13 +439,15 @@ var defaultPgType2GoType = map[string]*Info{
 
 	"uuid": &uuidGoTypeInfo,
 
-	"smallint": &int64GoTypeInfo,
-	"integer":  &int64GoTypeInfo,
 	"bigint":   &int64GoTypeInfo,
+	"int4":     &int64GoTypeInfo,
+	"int8":     &int64GoTypeInfo,
+	"integer":  &int64GoTypeInfo,
+	"smallint": &int64GoTypeInfo,
 
 	// Without knowing more about the shape of the data we are getting handed back,
 	// we will just use an untyped blob for json. We don't want to use an `interface{}`
-	// because and the user very well might have a struct that they want to deserialize
+	// because the user very well might have a struct that they want to deserialize
 	// stuff into.
 	"json":  &byteArrayGoTypeInfo,
 	"jsonb": &byteArrayGoTypeInfo,

--- a/include/include.go
+++ b/include/include.go
@@ -83,7 +83,6 @@ package include
 
 import (
 	"fmt"
-	"math"
 	"regexp"
 	"sort"
 	"strings"
@@ -505,8 +504,7 @@ func writeIdent(b *strings.Builder, ident string) {
 	if unquotedIdentRE.Match([]byte(ident)) {
 		b.WriteString(ident)
 	} else {
-		quotedQuotes := strings.Replace(
-			ident, `"`, `""`, int(math.MinInt64))
+		quotedQuotes := strings.ReplaceAll(ident, `"`, `""`)
 		b.WriteByte('"')
 		b.WriteString(quotedQuotes)
 		b.WriteByte('"')

--- a/include/include_test.go
+++ b/include/include_test.go
@@ -105,6 +105,9 @@ func TestParseSuccess(t *testing.T) {
 		{
 			src: `"123 "" _f"`,
 		},
+		{
+			src: `"a.b".c`,
+		},
 	}
 
 	for i, c := range cases {


### PR DESCRIPTION
This patch teaches pggen to work with tables from schemas besides
the default "public" schema. It now knows how to handle tables,
stored proceedures, and enum types defined in schemas besides the
"public" one.