### PR TITLE
add support for using defaults in inserts/upserts

### DIFF
--- a/cmd/pggen/test/db.sql
+++ b/cmd/pggen/test/db.sql
@@ -373,6 +373,13 @@ CREATE TABLE offset_table_fillings (
     i1 integer NOT NULL
 );
 
+CREATE TABLE default_values (
+    id SERIAL PRIMARY KEY,
+    defaulted_string text NOT NULL DEFAULT 'default value',
+    defaulted_int integer NOT NULL DEFAULT 42,
+    nondefault_string text NOT NULL UNIQUE
+);
+
 --
 -- Load Data
 --

--- a/cmd/pggen/test/models/pggen.toml
+++ b/cmd/pggen/test/models/pggen.toml
@@ -441,6 +441,9 @@
 [[table]]
     name = "offset_table_fillings"
 
+[[table]]
+    name = "default_values"
+
 ####################################################################################
 #                                                                                  #
 #                                     otherschema                                  #

--- a/examples/extending_models/models/pggen_prelude.gen.go
+++ b/examples/extending_models/models/pggen_prelude.gen.go
@@ -15,16 +15,22 @@ import (
 	"github.com/opendoor-labs/pggen"
 )
 
+type fieldNameAndIdx struct {
+	name string
+	idx  int
+}
+
 func genBulkInsertStmt(
 	table string,
-	fields []string,
+	fields []fieldNameAndIdx,
 	nrecords int,
 	pkeyName string,
 	includeID bool,
+	defaultFieldSet pggen.FieldSet,
 ) string {
 	var ret strings.Builder
 
-	genInsertCommon(&ret, table, fields, nrecords, pkeyName, includeID)
+	genInsertCommon(&ret, table, fields, nrecords, pkeyName, includeID, defaultFieldSet)
 
 	ret.WriteString(" RETURNING \"")
 	ret.WriteString(pkeyName)
@@ -33,25 +39,25 @@ func genBulkInsertStmt(
 	return ret.String()
 }
 
-// shared between the generated upsert code and genBulkInsertStmt
 func genInsertCommon(
 	into *strings.Builder,
 	table string,
-	fields []string,
+	fields []fieldNameAndIdx,
 	nrecords int,
 	pkeyName string,
 	includeID bool,
+	defaultFieldSet pggen.FieldSet,
 ) {
 	into.WriteString("INSERT INTO ")
 	into.WriteString(table)
 	into.WriteString(" (")
 	for i, field := range fields {
-		if !includeID && field == pkeyName {
+		if (!includeID && field.name == pkeyName) || defaultFieldSet.Test(field.idx) {
 			continue
 		}
 
 		into.WriteRune('"')
-		into.WriteString(field)
+		into.WriteString(field.name)
 		into.WriteRune('"')
 		if i+1 < len(fields) {
 			into.WriteRune(',')
@@ -60,8 +66,10 @@ func genInsertCommon(
 	into.WriteString(") VALUES ")
 
 	nInsertFields := len(fields)
-	if !includeID {
-		nInsertFields--
+	for _, field := range fields {
+		if defaultFieldSet.Test(field.idx) || (!includeID && field.name == pkeyName) {
+			nInsertFields--
+		}
 	}
 
 	nextArg := 1
@@ -87,7 +95,7 @@ func genInsertCommon(
 func genUpdateStmt(
 	table string,
 	pgPkey string,
-	fields []string,
+	fields []fieldNameAndIdx,
 	fieldMask pggen.FieldSet,
 	pkeyName string,
 ) string {
@@ -102,7 +110,7 @@ func genUpdateStmt(
 	argNo := 1
 	for i, f := range fields {
 		if fieldMask.Test(i) {
-			lhs = append(lhs, f)
+			lhs = append(lhs, f.name)
 			rhs = append(rhs, fmt.Sprintf("$%d", argNo))
 			argNo++
 		}

--- a/examples/id_in_set/models/models.gen.go
+++ b/examples/id_in_set/models/models.gen.go
@@ -277,12 +277,15 @@ func (p *pgClientImpl) bulkInsertFoo(
 		o(&opt)
 	}
 
+	defaultFields := opt.DefaultFields.Intersection(defaultableColsForFoo)
 	args := make([]interface{}, 0, 2*len(values))
 	for _, v := range values {
-		if opt.UsePkey {
+		if opt.UsePkey && !defaultFields.Test(FooIdFieldIndex) {
 			args = append(args, v.Id)
 		}
-		args = append(args, v.Value)
+		if !defaultFields.Test(FooValueFieldIndex) {
+			args = append(args, v.Value)
+		}
 	}
 
 	bulkInsertQuery := genBulkInsertStmt(
@@ -291,6 +294,7 @@ func (p *pgClientImpl) bulkInsertFoo(
 		len(values),
 		"id",
 		opt.UsePkey,
+		defaultFields,
 	)
 
 	rows, err := p.db.QueryContext(ctx, bulkInsertQuery, args...)
@@ -323,9 +327,15 @@ const (
 // For use as a 'fieldMask' parameter
 var FooAllFields pggen.FieldSet = pggen.NewFieldSetFilled(2)
 
-var fieldsForFoo []string = []string{
-	`id`,
-	`value`,
+var defaultableColsForFoo = func() pggen.FieldSet {
+	fs := pggen.NewFieldSet(FooMaxFieldIndex)
+	fs.Set(FooIdFieldIndex, true)
+	return fs
+}()
+
+var fieldsForFoo []fieldNameAndIdx = []fieldNameAndIdx{
+	{name: `id`, idx: FooIdFieldIndex},
+	{name: `value`, idx: FooValueFieldIndex},
 }
 
 // Update a Foo. 'value' must at the least have
@@ -490,6 +500,7 @@ func (p *pgClientImpl) bulkUpsertFoo(
 		constraintNames = []string{`id`}
 	}
 
+	defaultFields := options.DefaultFields.Intersection(defaultableColsForFoo)
 	var stmt strings.Builder
 	genInsertCommon(
 		&stmt,
@@ -498,6 +509,7 @@ func (p *pgClientImpl) bulkUpsertFoo(
 		len(values),
 		`id`,
 		options.UsePkey,
+		defaultFields,
 	)
 
 	setBits := fieldMask.CountSetBits()
@@ -543,10 +555,12 @@ func (p *pgClientImpl) bulkUpsertFoo(
 
 	args := make([]interface{}, 0, 2*len(values))
 	for _, v := range values {
-		if options.UsePkey {
+		if options.UsePkey && !defaultFields.Test(FooIdFieldIndex) {
 			args = append(args, v.Id)
 		}
-		args = append(args, v.Value)
+		if !defaultFields.Test(FooValueFieldIndex) {
+			args = append(args, v.Value)
+		}
 	}
 
 	rows, err := p.db.QueryContext(ctx, stmt.String(), args...)

--- a/examples/id_in_set/models/pggen_prelude.gen.go
+++ b/examples/id_in_set/models/pggen_prelude.gen.go
@@ -15,16 +15,22 @@ import (
 	"github.com/opendoor-labs/pggen"
 )
 
+type fieldNameAndIdx struct {
+	name string
+	idx  int
+}
+
 func genBulkInsertStmt(
 	table string,
-	fields []string,
+	fields []fieldNameAndIdx,
 	nrecords int,
 	pkeyName string,
 	includeID bool,
+	defaultFieldSet pggen.FieldSet,
 ) string {
 	var ret strings.Builder
 
-	genInsertCommon(&ret, table, fields, nrecords, pkeyName, includeID)
+	genInsertCommon(&ret, table, fields, nrecords, pkeyName, includeID, defaultFieldSet)
 
 	ret.WriteString(" RETURNING \"")
 	ret.WriteString(pkeyName)
@@ -33,25 +39,25 @@ func genBulkInsertStmt(
 	return ret.String()
 }
 
-// shared between the generated upsert code and genBulkInsertStmt
 func genInsertCommon(
 	into *strings.Builder,
 	table string,
-	fields []string,
+	fields []fieldNameAndIdx,
 	nrecords int,
 	pkeyName string,
 	includeID bool,
+	defaultFieldSet pggen.FieldSet,
 ) {
 	into.WriteString("INSERT INTO ")
 	into.WriteString(table)
 	into.WriteString(" (")
 	for i, field := range fields {
-		if !includeID && field == pkeyName {
+		if (!includeID && field.name == pkeyName) || defaultFieldSet.Test(field.idx) {
 			continue
 		}
 
 		into.WriteRune('"')
-		into.WriteString(field)
+		into.WriteString(field.name)
 		into.WriteRune('"')
 		if i+1 < len(fields) {
 			into.WriteRune(',')
@@ -60,8 +66,10 @@ func genInsertCommon(
 	into.WriteString(") VALUES ")
 
 	nInsertFields := len(fields)
-	if !includeID {
-		nInsertFields--
+	for _, field := range fields {
+		if defaultFieldSet.Test(field.idx) || (!includeID && field.name == pkeyName) {
+			nInsertFields--
+		}
 	}
 
 	nextArg := 1
@@ -87,7 +95,7 @@ func genInsertCommon(
 func genUpdateStmt(
 	table string,
 	pgPkey string,
-	fields []string,
+	fields []fieldNameAndIdx,
 	fieldMask pggen.FieldSet,
 	pkeyName string,
 ) string {
@@ -102,7 +110,7 @@ func genUpdateStmt(
 	argNo := 1
 	for i, f := range fields {
 		if fieldMask.Test(i) {
-			lhs = append(lhs, f)
+			lhs = append(lhs, f.name)
 			rhs = append(rhs, fmt.Sprintf("$%d", argNo))
 			argNo++
 		}

--- a/examples/include_specs/models/models.gen.go
+++ b/examples/include_specs/models/models.gen.go
@@ -279,13 +279,18 @@ func (p *pgClientImpl) bulkInsertGrandparent(
 		o(&opt)
 	}
 
+	defaultFields := opt.DefaultFields.Intersection(defaultableColsForGrandparent)
 	args := make([]interface{}, 0, 3*len(values))
 	for _, v := range values {
-		if opt.UsePkey {
+		if opt.UsePkey && !defaultFields.Test(GrandparentIdFieldIndex) {
 			args = append(args, v.Id)
 		}
-		args = append(args, v.Name)
-		args = append(args, v.FavoriteGrandkidId)
+		if !defaultFields.Test(GrandparentNameFieldIndex) {
+			args = append(args, v.Name)
+		}
+		if !defaultFields.Test(GrandparentFavoriteGrandkidIdFieldIndex) {
+			args = append(args, v.FavoriteGrandkidId)
+		}
 	}
 
 	bulkInsertQuery := genBulkInsertStmt(
@@ -294,6 +299,7 @@ func (p *pgClientImpl) bulkInsertGrandparent(
 		len(values),
 		"id",
 		opt.UsePkey,
+		defaultFields,
 	)
 
 	rows, err := p.db.QueryContext(ctx, bulkInsertQuery, args...)
@@ -327,10 +333,16 @@ const (
 // For use as a 'fieldMask' parameter
 var GrandparentAllFields pggen.FieldSet = pggen.NewFieldSetFilled(3)
 
-var fieldsForGrandparent []string = []string{
-	`id`,
-	`name`,
-	`favorite_grandkid_id`,
+var defaultableColsForGrandparent = func() pggen.FieldSet {
+	fs := pggen.NewFieldSet(GrandparentMaxFieldIndex)
+	fs.Set(GrandparentIdFieldIndex, true)
+	return fs
+}()
+
+var fieldsForGrandparent []fieldNameAndIdx = []fieldNameAndIdx{
+	{name: `id`, idx: GrandparentIdFieldIndex},
+	{name: `name`, idx: GrandparentNameFieldIndex},
+	{name: `favorite_grandkid_id`, idx: GrandparentFavoriteGrandkidIdFieldIndex},
 }
 
 // Update a Grandparent. 'value' must at the least have
@@ -498,6 +510,7 @@ func (p *pgClientImpl) bulkUpsertGrandparent(
 		constraintNames = []string{`id`}
 	}
 
+	defaultFields := options.DefaultFields.Intersection(defaultableColsForGrandparent)
 	var stmt strings.Builder
 	genInsertCommon(
 		&stmt,
@@ -506,6 +519,7 @@ func (p *pgClientImpl) bulkUpsertGrandparent(
 		len(values),
 		`id`,
 		options.UsePkey,
+		defaultFields,
 	)
 
 	setBits := fieldMask.CountSetBits()
@@ -555,11 +569,15 @@ func (p *pgClientImpl) bulkUpsertGrandparent(
 
 	args := make([]interface{}, 0, 3*len(values))
 	for _, v := range values {
-		if options.UsePkey {
+		if options.UsePkey && !defaultFields.Test(GrandparentIdFieldIndex) {
 			args = append(args, v.Id)
 		}
-		args = append(args, v.Name)
-		args = append(args, v.FavoriteGrandkidId)
+		if !defaultFields.Test(GrandparentNameFieldIndex) {
+			args = append(args, v.Name)
+		}
+		if !defaultFields.Test(GrandparentFavoriteGrandkidIdFieldIndex) {
+			args = append(args, v.FavoriteGrandkidId)
+		}
 	}
 
 	rows, err := p.db.QueryContext(ctx, stmt.String(), args...)
@@ -1105,13 +1123,18 @@ func (p *pgClientImpl) bulkInsertParent(
 		o(&opt)
 	}
 
+	defaultFields := opt.DefaultFields.Intersection(defaultableColsForParent)
 	args := make([]interface{}, 0, 3*len(values))
 	for _, v := range values {
-		if opt.UsePkey {
+		if opt.UsePkey && !defaultFields.Test(ParentIdFieldIndex) {
 			args = append(args, v.Id)
 		}
-		args = append(args, v.GrandparentId)
-		args = append(args, v.Name)
+		if !defaultFields.Test(ParentGrandparentIdFieldIndex) {
+			args = append(args, v.GrandparentId)
+		}
+		if !defaultFields.Test(ParentNameFieldIndex) {
+			args = append(args, v.Name)
+		}
 	}
 
 	bulkInsertQuery := genBulkInsertStmt(
@@ -1120,6 +1143,7 @@ func (p *pgClientImpl) bulkInsertParent(
 		len(values),
 		"id",
 		opt.UsePkey,
+		defaultFields,
 	)
 
 	rows, err := p.db.QueryContext(ctx, bulkInsertQuery, args...)
@@ -1153,10 +1177,16 @@ const (
 // For use as a 'fieldMask' parameter
 var ParentAllFields pggen.FieldSet = pggen.NewFieldSetFilled(3)
 
-var fieldsForParent []string = []string{
-	`id`,
-	`grandparent_id`,
-	`name`,
+var defaultableColsForParent = func() pggen.FieldSet {
+	fs := pggen.NewFieldSet(ParentMaxFieldIndex)
+	fs.Set(ParentIdFieldIndex, true)
+	return fs
+}()
+
+var fieldsForParent []fieldNameAndIdx = []fieldNameAndIdx{
+	{name: `id`, idx: ParentIdFieldIndex},
+	{name: `grandparent_id`, idx: ParentGrandparentIdFieldIndex},
+	{name: `name`, idx: ParentNameFieldIndex},
 }
 
 // Update a Parent. 'value' must at the least have
@@ -1324,6 +1354,7 @@ func (p *pgClientImpl) bulkUpsertParent(
 		constraintNames = []string{`id`}
 	}
 
+	defaultFields := options.DefaultFields.Intersection(defaultableColsForParent)
 	var stmt strings.Builder
 	genInsertCommon(
 		&stmt,
@@ -1332,6 +1363,7 @@ func (p *pgClientImpl) bulkUpsertParent(
 		len(values),
 		`id`,
 		options.UsePkey,
+		defaultFields,
 	)
 
 	setBits := fieldMask.CountSetBits()
@@ -1381,11 +1413,15 @@ func (p *pgClientImpl) bulkUpsertParent(
 
 	args := make([]interface{}, 0, 3*len(values))
 	for _, v := range values {
-		if options.UsePkey {
+		if options.UsePkey && !defaultFields.Test(ParentIdFieldIndex) {
 			args = append(args, v.Id)
 		}
-		args = append(args, v.GrandparentId)
-		args = append(args, v.Name)
+		if !defaultFields.Test(ParentGrandparentIdFieldIndex) {
+			args = append(args, v.GrandparentId)
+		}
+		if !defaultFields.Test(ParentNameFieldIndex) {
+			args = append(args, v.Name)
+		}
 	}
 
 	rows, err := p.db.QueryContext(ctx, stmt.String(), args...)
@@ -1925,13 +1961,18 @@ func (p *pgClientImpl) bulkInsertChild(
 		o(&opt)
 	}
 
+	defaultFields := opt.DefaultFields.Intersection(defaultableColsForChild)
 	args := make([]interface{}, 0, 3*len(values))
 	for _, v := range values {
-		if opt.UsePkey {
+		if opt.UsePkey && !defaultFields.Test(ChildIdFieldIndex) {
 			args = append(args, v.Id)
 		}
-		args = append(args, v.ParentId)
-		args = append(args, v.Name)
+		if !defaultFields.Test(ChildParentIdFieldIndex) {
+			args = append(args, v.ParentId)
+		}
+		if !defaultFields.Test(ChildNameFieldIndex) {
+			args = append(args, v.Name)
+		}
 	}
 
 	bulkInsertQuery := genBulkInsertStmt(
@@ -1940,6 +1981,7 @@ func (p *pgClientImpl) bulkInsertChild(
 		len(values),
 		"id",
 		opt.UsePkey,
+		defaultFields,
 	)
 
 	rows, err := p.db.QueryContext(ctx, bulkInsertQuery, args...)
@@ -1973,10 +2015,16 @@ const (
 // For use as a 'fieldMask' parameter
 var ChildAllFields pggen.FieldSet = pggen.NewFieldSetFilled(3)
 
-var fieldsForChild []string = []string{
-	`id`,
-	`parent_id`,
-	`name`,
+var defaultableColsForChild = func() pggen.FieldSet {
+	fs := pggen.NewFieldSet(ChildMaxFieldIndex)
+	fs.Set(ChildIdFieldIndex, true)
+	return fs
+}()
+
+var fieldsForChild []fieldNameAndIdx = []fieldNameAndIdx{
+	{name: `id`, idx: ChildIdFieldIndex},
+	{name: `parent_id`, idx: ChildParentIdFieldIndex},
+	{name: `name`, idx: ChildNameFieldIndex},
 }
 
 // Update a Child. 'value' must at the least have
@@ -2144,6 +2192,7 @@ func (p *pgClientImpl) bulkUpsertChild(
 		constraintNames = []string{`id`}
 	}
 
+	defaultFields := options.DefaultFields.Intersection(defaultableColsForChild)
 	var stmt strings.Builder
 	genInsertCommon(
 		&stmt,
@@ -2152,6 +2201,7 @@ func (p *pgClientImpl) bulkUpsertChild(
 		len(values),
 		`id`,
 		options.UsePkey,
+		defaultFields,
 	)
 
 	setBits := fieldMask.CountSetBits()
@@ -2201,11 +2251,15 @@ func (p *pgClientImpl) bulkUpsertChild(
 
 	args := make([]interface{}, 0, 3*len(values))
 	for _, v := range values {
-		if options.UsePkey {
+		if options.UsePkey && !defaultFields.Test(ChildIdFieldIndex) {
 			args = append(args, v.Id)
 		}
-		args = append(args, v.ParentId)
-		args = append(args, v.Name)
+		if !defaultFields.Test(ChildParentIdFieldIndex) {
+			args = append(args, v.ParentId)
+		}
+		if !defaultFields.Test(ChildNameFieldIndex) {
+			args = append(args, v.Name)
+		}
 	}
 
 	rows, err := p.db.QueryContext(ctx, stmt.String(), args...)

--- a/examples/include_specs/models/pggen_prelude.gen.go
+++ b/examples/include_specs/models/pggen_prelude.gen.go
@@ -15,16 +15,22 @@ import (
 	"github.com/opendoor-labs/pggen"
 )
 
+type fieldNameAndIdx struct {
+	name string
+	idx  int
+}
+
 func genBulkInsertStmt(
 	table string,
-	fields []string,
+	fields []fieldNameAndIdx,
 	nrecords int,
 	pkeyName string,
 	includeID bool,
+	defaultFieldSet pggen.FieldSet,
 ) string {
 	var ret strings.Builder
 
-	genInsertCommon(&ret, table, fields, nrecords, pkeyName, includeID)
+	genInsertCommon(&ret, table, fields, nrecords, pkeyName, includeID, defaultFieldSet)
 
 	ret.WriteString(" RETURNING \"")
 	ret.WriteString(pkeyName)
@@ -33,25 +39,25 @@ func genBulkInsertStmt(
 	return ret.String()
 }
 
-// shared between the generated upsert code and genBulkInsertStmt
 func genInsertCommon(
 	into *strings.Builder,
 	table string,
-	fields []string,
+	fields []fieldNameAndIdx,
 	nrecords int,
 	pkeyName string,
 	includeID bool,
+	defaultFieldSet pggen.FieldSet,
 ) {
 	into.WriteString("INSERT INTO ")
 	into.WriteString(table)
 	into.WriteString(" (")
 	for i, field := range fields {
-		if !includeID && field == pkeyName {
+		if (!includeID && field.name == pkeyName) || defaultFieldSet.Test(field.idx) {
 			continue
 		}
 
 		into.WriteRune('"')
-		into.WriteString(field)
+		into.WriteString(field.name)
 		into.WriteRune('"')
 		if i+1 < len(fields) {
 			into.WriteRune(',')
@@ -60,8 +66,10 @@ func genInsertCommon(
 	into.WriteString(") VALUES ")
 
 	nInsertFields := len(fields)
-	if !includeID {
-		nInsertFields--
+	for _, field := range fields {
+		if defaultFieldSet.Test(field.idx) || (!includeID && field.name == pkeyName) {
+			nInsertFields--
+		}
 	}
 
 	nextArg := 1
@@ -87,7 +95,7 @@ func genInsertCommon(
 func genUpdateStmt(
 	table string,
 	pgPkey string,
-	fields []string,
+	fields []fieldNameAndIdx,
 	fieldMask pggen.FieldSet,
 	pkeyName string,
 ) string {
@@ -102,7 +110,7 @@ func genUpdateStmt(
 	argNo := 1
 	for i, f := range fields {
 		if fieldMask.Test(i) {
-			lhs = append(lhs, f)
+			lhs = append(lhs, f.name)
 			rhs = append(rhs, fmt.Sprintf("$%d", argNo))
 			argNo++
 		}

--- a/examples/middleware/models/pggen_prelude.gen.go
+++ b/examples/middleware/models/pggen_prelude.gen.go
@@ -15,16 +15,22 @@ import (
 	"github.com/opendoor-labs/pggen"
 )
 
+type fieldNameAndIdx struct {
+	name string
+	idx  int
+}
+
 func genBulkInsertStmt(
 	table string,
-	fields []string,
+	fields []fieldNameAndIdx,
 	nrecords int,
 	pkeyName string,
 	includeID bool,
+	defaultFieldSet pggen.FieldSet,
 ) string {
 	var ret strings.Builder
 
-	genInsertCommon(&ret, table, fields, nrecords, pkeyName, includeID)
+	genInsertCommon(&ret, table, fields, nrecords, pkeyName, includeID, defaultFieldSet)
 
 	ret.WriteString(" RETURNING \"")
 	ret.WriteString(pkeyName)
@@ -33,25 +39,25 @@ func genBulkInsertStmt(
 	return ret.String()
 }
 
-// shared between the generated upsert code and genBulkInsertStmt
 func genInsertCommon(
 	into *strings.Builder,
 	table string,
-	fields []string,
+	fields []fieldNameAndIdx,
 	nrecords int,
 	pkeyName string,
 	includeID bool,
+	defaultFieldSet pggen.FieldSet,
 ) {
 	into.WriteString("INSERT INTO ")
 	into.WriteString(table)
 	into.WriteString(" (")
 	for i, field := range fields {
-		if !includeID && field == pkeyName {
+		if (!includeID && field.name == pkeyName) || defaultFieldSet.Test(field.idx) {
 			continue
 		}
 
 		into.WriteRune('"')
-		into.WriteString(field)
+		into.WriteString(field.name)
 		into.WriteRune('"')
 		if i+1 < len(fields) {
 			into.WriteRune(',')
@@ -60,8 +66,10 @@ func genInsertCommon(
 	into.WriteString(") VALUES ")
 
 	nInsertFields := len(fields)
-	if !includeID {
-		nInsertFields--
+	for _, field := range fields {
+		if defaultFieldSet.Test(field.idx) || (!includeID && field.name == pkeyName) {
+			nInsertFields--
+		}
 	}
 
 	nextArg := 1
@@ -87,7 +95,7 @@ func genInsertCommon(
 func genUpdateStmt(
 	table string,
 	pgPkey string,
-	fields []string,
+	fields []fieldNameAndIdx,
 	fieldMask pggen.FieldSet,
 	pkeyName string,
 ) string {
@@ -102,7 +110,7 @@ func genUpdateStmt(
 	argNo := 1
 	for i, f := range fields {
 		if fieldMask.Test(i) {
-			lhs = append(lhs, f)
+			lhs = append(lhs, f.name)
 			rhs = append(rhs, fmt.Sprintf("$%d", argNo))
 			argNo++
 		}

--- a/examples/query/models/models.gen.go
+++ b/examples/query/models/models.gen.go
@@ -279,13 +279,18 @@ func (p *pgClientImpl) bulkInsertUser(
 		o(&opt)
 	}
 
+	defaultFields := opt.DefaultFields.Intersection(defaultableColsForUser)
 	args := make([]interface{}, 0, 3*len(values))
 	for _, v := range values {
-		if opt.UsePkey {
+		if opt.UsePkey && !defaultFields.Test(UserIdFieldIndex) {
 			args = append(args, v.Id)
 		}
-		args = append(args, v.Email)
-		args = append(args, v.Nickname)
+		if !defaultFields.Test(UserEmailFieldIndex) {
+			args = append(args, v.Email)
+		}
+		if !defaultFields.Test(UserNicknameFieldIndex) {
+			args = append(args, v.Nickname)
+		}
 	}
 
 	bulkInsertQuery := genBulkInsertStmt(
@@ -294,6 +299,7 @@ func (p *pgClientImpl) bulkInsertUser(
 		len(values),
 		"id",
 		opt.UsePkey,
+		defaultFields,
 	)
 
 	rows, err := p.db.QueryContext(ctx, bulkInsertQuery, args...)
@@ -327,10 +333,16 @@ const (
 // For use as a 'fieldMask' parameter
 var UserAllFields pggen.FieldSet = pggen.NewFieldSetFilled(3)
 
-var fieldsForUser []string = []string{
-	`id`,
-	`email`,
-	`nickname`,
+var defaultableColsForUser = func() pggen.FieldSet {
+	fs := pggen.NewFieldSet(UserMaxFieldIndex)
+	fs.Set(UserIdFieldIndex, true)
+	return fs
+}()
+
+var fieldsForUser []fieldNameAndIdx = []fieldNameAndIdx{
+	{name: `id`, idx: UserIdFieldIndex},
+	{name: `email`, idx: UserEmailFieldIndex},
+	{name: `nickname`, idx: UserNicknameFieldIndex},
 }
 
 // Update a User. 'value' must at the least have
@@ -498,6 +510,7 @@ func (p *pgClientImpl) bulkUpsertUser(
 		constraintNames = []string{`id`}
 	}
 
+	defaultFields := options.DefaultFields.Intersection(defaultableColsForUser)
 	var stmt strings.Builder
 	genInsertCommon(
 		&stmt,
@@ -506,6 +519,7 @@ func (p *pgClientImpl) bulkUpsertUser(
 		len(values),
 		`id`,
 		options.UsePkey,
+		defaultFields,
 	)
 
 	setBits := fieldMask.CountSetBits()
@@ -555,11 +569,15 @@ func (p *pgClientImpl) bulkUpsertUser(
 
 	args := make([]interface{}, 0, 3*len(values))
 	for _, v := range values {
-		if options.UsePkey {
+		if options.UsePkey && !defaultFields.Test(UserIdFieldIndex) {
 			args = append(args, v.Id)
 		}
-		args = append(args, v.Email)
-		args = append(args, v.Nickname)
+		if !defaultFields.Test(UserEmailFieldIndex) {
+			args = append(args, v.Email)
+		}
+		if !defaultFields.Test(UserNicknameFieldIndex) {
+			args = append(args, v.Nickname)
+		}
 	}
 
 	rows, err := p.db.QueryContext(ctx, stmt.String(), args...)

--- a/examples/query/models/pggen_prelude.gen.go
+++ b/examples/query/models/pggen_prelude.gen.go
@@ -15,16 +15,22 @@ import (
 	"github.com/opendoor-labs/pggen"
 )
 
+type fieldNameAndIdx struct {
+	name string
+	idx  int
+}
+
 func genBulkInsertStmt(
 	table string,
-	fields []string,
+	fields []fieldNameAndIdx,
 	nrecords int,
 	pkeyName string,
 	includeID bool,
+	defaultFieldSet pggen.FieldSet,
 ) string {
 	var ret strings.Builder
 
-	genInsertCommon(&ret, table, fields, nrecords, pkeyName, includeID)
+	genInsertCommon(&ret, table, fields, nrecords, pkeyName, includeID, defaultFieldSet)
 
 	ret.WriteString(" RETURNING \"")
 	ret.WriteString(pkeyName)
@@ -33,25 +39,25 @@ func genBulkInsertStmt(
 	return ret.String()
 }
 
-// shared between the generated upsert code and genBulkInsertStmt
 func genInsertCommon(
 	into *strings.Builder,
 	table string,
-	fields []string,
+	fields []fieldNameAndIdx,
 	nrecords int,
 	pkeyName string,
 	includeID bool,
+	defaultFieldSet pggen.FieldSet,
 ) {
 	into.WriteString("INSERT INTO ")
 	into.WriteString(table)
 	into.WriteString(" (")
 	for i, field := range fields {
-		if !includeID && field == pkeyName {
+		if (!includeID && field.name == pkeyName) || defaultFieldSet.Test(field.idx) {
 			continue
 		}
 
 		into.WriteRune('"')
-		into.WriteString(field)
+		into.WriteString(field.name)
 		into.WriteRune('"')
 		if i+1 < len(fields) {
 			into.WriteRune(',')
@@ -60,8 +66,10 @@ func genInsertCommon(
 	into.WriteString(") VALUES ")
 
 	nInsertFields := len(fields)
-	if !includeID {
-		nInsertFields--
+	for _, field := range fields {
+		if defaultFieldSet.Test(field.idx) || (!includeID && field.name == pkeyName) {
+			nInsertFields--
+		}
 	}
 
 	nextArg := 1
@@ -87,7 +95,7 @@ func genInsertCommon(
 func genUpdateStmt(
 	table string,
 	pgPkey string,
-	fields []string,
+	fields []fieldNameAndIdx,
 	fieldMask pggen.FieldSet,
 	pkeyName string,
 ) string {
@@ -102,7 +110,7 @@ func genUpdateStmt(
 	argNo := 1
 	for i, f := range fields {
 		if fieldMask.Test(i) {
-			lhs = append(lhs, f)
+			lhs = append(lhs, f.name)
 			rhs = append(rhs, fmt.Sprintf("$%d", argNo))
 			argNo++
 		}

--- a/examples/query_argument_names/models/pggen_prelude.gen.go
+++ b/examples/query_argument_names/models/pggen_prelude.gen.go
@@ -15,16 +15,22 @@ import (
 	"github.com/opendoor-labs/pggen"
 )
 
+type fieldNameAndIdx struct {
+	name string
+	idx  int
+}
+
 func genBulkInsertStmt(
 	table string,
-	fields []string,
+	fields []fieldNameAndIdx,
 	nrecords int,
 	pkeyName string,
 	includeID bool,
+	defaultFieldSet pggen.FieldSet,
 ) string {
 	var ret strings.Builder
 
-	genInsertCommon(&ret, table, fields, nrecords, pkeyName, includeID)
+	genInsertCommon(&ret, table, fields, nrecords, pkeyName, includeID, defaultFieldSet)
 
 	ret.WriteString(" RETURNING \"")
 	ret.WriteString(pkeyName)
@@ -33,25 +39,25 @@ func genBulkInsertStmt(
 	return ret.String()
 }
 
-// shared between the generated upsert code and genBulkInsertStmt
 func genInsertCommon(
 	into *strings.Builder,
 	table string,
-	fields []string,
+	fields []fieldNameAndIdx,
 	nrecords int,
 	pkeyName string,
 	includeID bool,
+	defaultFieldSet pggen.FieldSet,
 ) {
 	into.WriteString("INSERT INTO ")
 	into.WriteString(table)
 	into.WriteString(" (")
 	for i, field := range fields {
-		if !includeID && field == pkeyName {
+		if (!includeID && field.name == pkeyName) || defaultFieldSet.Test(field.idx) {
 			continue
 		}
 
 		into.WriteRune('"')
-		into.WriteString(field)
+		into.WriteString(field.name)
 		into.WriteRune('"')
 		if i+1 < len(fields) {
 			into.WriteRune(',')
@@ -60,8 +66,10 @@ func genInsertCommon(
 	into.WriteString(") VALUES ")
 
 	nInsertFields := len(fields)
-	if !includeID {
-		nInsertFields--
+	for _, field := range fields {
+		if defaultFieldSet.Test(field.idx) || (!includeID && field.name == pkeyName) {
+			nInsertFields--
+		}
 	}
 
 	nextArg := 1
@@ -87,7 +95,7 @@ func genInsertCommon(
 func genUpdateStmt(
 	table string,
 	pgPkey string,
-	fields []string,
+	fields []fieldNameAndIdx,
 	fieldMask pggen.FieldSet,
 	pkeyName string,
 ) string {
@@ -102,7 +110,7 @@ func genUpdateStmt(
 	argNo := 1
 	for i, f := range fields {
 		if fieldMask.Test(i) {
-			lhs = append(lhs, f)
+			lhs = append(lhs, f.name)
 			rhs = append(rhs, fmt.Sprintf("$%d", argNo))
 			argNo++
 		}

--- a/examples/single_results/models/models.gen.go
+++ b/examples/single_results/models/models.gen.go
@@ -277,12 +277,15 @@ func (p *pgClientImpl) bulkInsertFoo(
 		o(&opt)
 	}
 
+	defaultFields := opt.DefaultFields.Intersection(defaultableColsForFoo)
 	args := make([]interface{}, 0, 2*len(values))
 	for _, v := range values {
-		if opt.UsePkey {
+		if opt.UsePkey && !defaultFields.Test(FooIdFieldIndex) {
 			args = append(args, v.Id)
 		}
-		args = append(args, v.Value)
+		if !defaultFields.Test(FooValueFieldIndex) {
+			args = append(args, v.Value)
+		}
 	}
 
 	bulkInsertQuery := genBulkInsertStmt(
@@ -291,6 +294,7 @@ func (p *pgClientImpl) bulkInsertFoo(
 		len(values),
 		"id",
 		opt.UsePkey,
+		defaultFields,
 	)
 
 	rows, err := p.db.QueryContext(ctx, bulkInsertQuery, args...)
@@ -323,9 +327,15 @@ const (
 // For use as a 'fieldMask' parameter
 var FooAllFields pggen.FieldSet = pggen.NewFieldSetFilled(2)
 
-var fieldsForFoo []string = []string{
-	`id`,
-	`value`,
+var defaultableColsForFoo = func() pggen.FieldSet {
+	fs := pggen.NewFieldSet(FooMaxFieldIndex)
+	fs.Set(FooIdFieldIndex, true)
+	return fs
+}()
+
+var fieldsForFoo []fieldNameAndIdx = []fieldNameAndIdx{
+	{name: `id`, idx: FooIdFieldIndex},
+	{name: `value`, idx: FooValueFieldIndex},
 }
 
 // Update a Foo. 'value' must at the least have
@@ -490,6 +500,7 @@ func (p *pgClientImpl) bulkUpsertFoo(
 		constraintNames = []string{`id`}
 	}
 
+	defaultFields := options.DefaultFields.Intersection(defaultableColsForFoo)
 	var stmt strings.Builder
 	genInsertCommon(
 		&stmt,
@@ -498,6 +509,7 @@ func (p *pgClientImpl) bulkUpsertFoo(
 		len(values),
 		`id`,
 		options.UsePkey,
+		defaultFields,
 	)
 
 	setBits := fieldMask.CountSetBits()
@@ -543,10 +555,12 @@ func (p *pgClientImpl) bulkUpsertFoo(
 
 	args := make([]interface{}, 0, 2*len(values))
 	for _, v := range values {
-		if options.UsePkey {
+		if options.UsePkey && !defaultFields.Test(FooIdFieldIndex) {
 			args = append(args, v.Id)
 		}
-		args = append(args, v.Value)
+		if !defaultFields.Test(FooValueFieldIndex) {
+			args = append(args, v.Value)
+		}
 	}
 
 	rows, err := p.db.QueryContext(ctx, stmt.String(), args...)

--- a/examples/single_results/models/pggen_prelude.gen.go
+++ b/examples/single_results/models/pggen_prelude.gen.go
@@ -15,16 +15,22 @@ import (
 	"github.com/opendoor-labs/pggen"
 )
 
+type fieldNameAndIdx struct {
+	name string
+	idx  int
+}
+
 func genBulkInsertStmt(
 	table string,
-	fields []string,
+	fields []fieldNameAndIdx,
 	nrecords int,
 	pkeyName string,
 	includeID bool,
+	defaultFieldSet pggen.FieldSet,
 ) string {
 	var ret strings.Builder
 
-	genInsertCommon(&ret, table, fields, nrecords, pkeyName, includeID)
+	genInsertCommon(&ret, table, fields, nrecords, pkeyName, includeID, defaultFieldSet)
 
 	ret.WriteString(" RETURNING \"")
 	ret.WriteString(pkeyName)
@@ -33,25 +39,25 @@ func genBulkInsertStmt(
 	return ret.String()
 }
 
-// shared between the generated upsert code and genBulkInsertStmt
 func genInsertCommon(
 	into *strings.Builder,
 	table string,
-	fields []string,
+	fields []fieldNameAndIdx,
 	nrecords int,
 	pkeyName string,
 	includeID bool,
+	defaultFieldSet pggen.FieldSet,
 ) {
 	into.WriteString("INSERT INTO ")
 	into.WriteString(table)
 	into.WriteString(" (")
 	for i, field := range fields {
-		if !includeID && field == pkeyName {
+		if (!includeID && field.name == pkeyName) || defaultFieldSet.Test(field.idx) {
 			continue
 		}
 
 		into.WriteRune('"')
-		into.WriteString(field)
+		into.WriteString(field.name)
 		into.WriteRune('"')
 		if i+1 < len(fields) {
 			into.WriteRune(',')
@@ -60,8 +66,10 @@ func genInsertCommon(
 	into.WriteString(") VALUES ")
 
 	nInsertFields := len(fields)
-	if !includeID {
-		nInsertFields--
+	for _, field := range fields {
+		if defaultFieldSet.Test(field.idx) || (!includeID && field.name == pkeyName) {
+			nInsertFields--
+		}
 	}
 
 	nextArg := 1
@@ -87,7 +95,7 @@ func genInsertCommon(
 func genUpdateStmt(
 	table string,
 	pgPkey string,
-	fields []string,
+	fields []fieldNameAndIdx,
 	fieldMask pggen.FieldSet,
 	pkeyName string,
 ) string {
@@ -102,7 +110,7 @@ func genUpdateStmt(
 	argNo := 1
 	for i, f := range fields {
 		if fieldMask.Test(i) {
-			lhs = append(lhs, f)
+			lhs = append(lhs, f.name)
 			rhs = append(rhs, fmt.Sprintf("$%d", argNo))
 			argNo++
 		}

--- a/examples/statement/models/models.gen.go
+++ b/examples/statement/models/models.gen.go
@@ -275,13 +275,18 @@ func (p *pgClientImpl) bulkInsertUser(
 		o(&opt)
 	}
 
+	defaultFields := opt.DefaultFields.Intersection(defaultableColsForUser)
 	args := make([]interface{}, 0, 3*len(values))
 	for _, v := range values {
-		if opt.UsePkey {
+		if opt.UsePkey && !defaultFields.Test(UserIdFieldIndex) {
 			args = append(args, v.Id)
 		}
-		args = append(args, v.Email)
-		args = append(args, v.Nickname)
+		if !defaultFields.Test(UserEmailFieldIndex) {
+			args = append(args, v.Email)
+		}
+		if !defaultFields.Test(UserNicknameFieldIndex) {
+			args = append(args, v.Nickname)
+		}
 	}
 
 	bulkInsertQuery := genBulkInsertStmt(
@@ -290,6 +295,7 @@ func (p *pgClientImpl) bulkInsertUser(
 		len(values),
 		"id",
 		opt.UsePkey,
+		defaultFields,
 	)
 
 	rows, err := p.db.QueryContext(ctx, bulkInsertQuery, args...)
@@ -323,10 +329,16 @@ const (
 // For use as a 'fieldMask' parameter
 var UserAllFields pggen.FieldSet = pggen.NewFieldSetFilled(3)
 
-var fieldsForUser []string = []string{
-	`id`,
-	`email`,
-	`nickname`,
+var defaultableColsForUser = func() pggen.FieldSet {
+	fs := pggen.NewFieldSet(UserMaxFieldIndex)
+	fs.Set(UserIdFieldIndex, true)
+	return fs
+}()
+
+var fieldsForUser []fieldNameAndIdx = []fieldNameAndIdx{
+	{name: `id`, idx: UserIdFieldIndex},
+	{name: `email`, idx: UserEmailFieldIndex},
+	{name: `nickname`, idx: UserNicknameFieldIndex},
 }
 
 // Update a User. 'value' must at the least have
@@ -494,6 +506,7 @@ func (p *pgClientImpl) bulkUpsertUser(
 		constraintNames = []string{`id`}
 	}
 
+	defaultFields := options.DefaultFields.Intersection(defaultableColsForUser)
 	var stmt strings.Builder
 	genInsertCommon(
 		&stmt,
@@ -502,6 +515,7 @@ func (p *pgClientImpl) bulkUpsertUser(
 		len(values),
 		`id`,
 		options.UsePkey,
+		defaultFields,
 	)
 
 	setBits := fieldMask.CountSetBits()
@@ -551,11 +565,15 @@ func (p *pgClientImpl) bulkUpsertUser(
 
 	args := make([]interface{}, 0, 3*len(values))
 	for _, v := range values {
-		if options.UsePkey {
+		if options.UsePkey && !defaultFields.Test(UserIdFieldIndex) {
 			args = append(args, v.Id)
 		}
-		args = append(args, v.Email)
-		args = append(args, v.Nickname)
+		if !defaultFields.Test(UserEmailFieldIndex) {
+			args = append(args, v.Email)
+		}
+		if !defaultFields.Test(UserNicknameFieldIndex) {
+			args = append(args, v.Nickname)
+		}
 	}
 
 	rows, err := p.db.QueryContext(ctx, stmt.String(), args...)

--- a/examples/statement/models/pggen_prelude.gen.go
+++ b/examples/statement/models/pggen_prelude.gen.go
@@ -15,16 +15,22 @@ import (
 	"github.com/opendoor-labs/pggen"
 )
 
+type fieldNameAndIdx struct {
+	name string
+	idx  int
+}
+
 func genBulkInsertStmt(
 	table string,
-	fields []string,
+	fields []fieldNameAndIdx,
 	nrecords int,
 	pkeyName string,
 	includeID bool,
+	defaultFieldSet pggen.FieldSet,
 ) string {
 	var ret strings.Builder
 
-	genInsertCommon(&ret, table, fields, nrecords, pkeyName, includeID)
+	genInsertCommon(&ret, table, fields, nrecords, pkeyName, includeID, defaultFieldSet)
 
 	ret.WriteString(" RETURNING \"")
 	ret.WriteString(pkeyName)
@@ -33,25 +39,25 @@ func genBulkInsertStmt(
 	return ret.String()
 }
 
-// shared between the generated upsert code and genBulkInsertStmt
 func genInsertCommon(
 	into *strings.Builder,
 	table string,
-	fields []string,
+	fields []fieldNameAndIdx,
 	nrecords int,
 	pkeyName string,
 	includeID bool,
+	defaultFieldSet pggen.FieldSet,
 ) {
 	into.WriteString("INSERT INTO ")
 	into.WriteString(table)
 	into.WriteString(" (")
 	for i, field := range fields {
-		if !includeID && field == pkeyName {
+		if (!includeID && field.name == pkeyName) || defaultFieldSet.Test(field.idx) {
 			continue
 		}
 
 		into.WriteRune('"')
-		into.WriteString(field)
+		into.WriteString(field.name)
 		into.WriteRune('"')
 		if i+1 < len(fields) {
 			into.WriteRune(',')
@@ -60,8 +66,10 @@ func genInsertCommon(
 	into.WriteString(") VALUES ")
 
 	nInsertFields := len(fields)
-	if !includeID {
-		nInsertFields--
+	for _, field := range fields {
+		if defaultFieldSet.Test(field.idx) || (!includeID && field.name == pkeyName) {
+			nInsertFields--
+		}
 	}
 
 	nextArg := 1
@@ -87,7 +95,7 @@ func genInsertCommon(
 func genUpdateStmt(
 	table string,
 	pgPkey string,
-	fields []string,
+	fields []fieldNameAndIdx,
 	fieldMask pggen.FieldSet,
 	pkeyName string,
 ) string {
@@ -102,7 +110,7 @@ func genUpdateStmt(
 	argNo := 1
 	for i, f := range fields {
 		if fieldMask.Test(i) {
-			lhs = append(lhs, f)
+			lhs = append(lhs, f.name)
 			rhs = append(rhs, fmt.Sprintf("$%d", argNo))
 			argNo++
 		}

--- a/examples/timestamps/models/models.gen.go
+++ b/examples/timestamps/models/models.gen.go
@@ -287,15 +287,24 @@ func (p *pgClientImpl) bulkInsertUser(
 		values[i].UpdatedAt = updatedAt
 	}
 
+	defaultFields := opt.DefaultFields.Intersection(defaultableColsForUser)
 	args := make([]interface{}, 0, 5*len(values))
 	for _, v := range values {
-		if opt.UsePkey {
+		if opt.UsePkey && !defaultFields.Test(UserIdFieldIndex) {
 			args = append(args, v.Id)
 		}
-		args = append(args, v.Email)
-		args = append(args, v.CreatedAt)
-		args = append(args, v.UpdatedAt)
-		args = append(args, v.DeletedAt)
+		if !defaultFields.Test(UserEmailFieldIndex) {
+			args = append(args, v.Email)
+		}
+		if !defaultFields.Test(UserCreatedAtFieldIndex) {
+			args = append(args, v.CreatedAt)
+		}
+		if !defaultFields.Test(UserUpdatedAtFieldIndex) {
+			args = append(args, v.UpdatedAt)
+		}
+		if !defaultFields.Test(UserDeletedAtFieldIndex) {
+			args = append(args, v.DeletedAt)
+		}
 	}
 
 	bulkInsertQuery := genBulkInsertStmt(
@@ -304,6 +313,7 @@ func (p *pgClientImpl) bulkInsertUser(
 		len(values),
 		"id",
 		opt.UsePkey,
+		defaultFields,
 	)
 
 	rows, err := p.db.QueryContext(ctx, bulkInsertQuery, args...)
@@ -339,12 +349,18 @@ const (
 // For use as a 'fieldMask' parameter
 var UserAllFields pggen.FieldSet = pggen.NewFieldSetFilled(5)
 
-var fieldsForUser []string = []string{
-	`id`,
-	`email`,
-	`created_at`,
-	`updated_at`,
-	`deleted_at`,
+var defaultableColsForUser = func() pggen.FieldSet {
+	fs := pggen.NewFieldSet(UserMaxFieldIndex)
+	fs.Set(UserIdFieldIndex, true)
+	return fs
+}()
+
+var fieldsForUser []fieldNameAndIdx = []fieldNameAndIdx{
+	{name: `id`, idx: UserIdFieldIndex},
+	{name: `email`, idx: UserEmailFieldIndex},
+	{name: `created_at`, idx: UserCreatedAtFieldIndex},
+	{name: `updated_at`, idx: UserUpdatedAtFieldIndex},
+	{name: `deleted_at`, idx: UserDeletedAtFieldIndex},
 }
 
 // Update a User. 'value' must at the least have
@@ -532,6 +548,7 @@ func (p *pgClientImpl) bulkUpsertUser(
 	}
 	fieldMask.Set(UserUpdatedAtFieldIndex, true)
 
+	defaultFields := options.DefaultFields.Intersection(defaultableColsForUser)
 	var stmt strings.Builder
 	genInsertCommon(
 		&stmt,
@@ -540,6 +557,7 @@ func (p *pgClientImpl) bulkUpsertUser(
 		len(values),
 		`id`,
 		options.UsePkey,
+		defaultFields,
 	)
 
 	setBits := fieldMask.CountSetBits()
@@ -597,13 +615,21 @@ func (p *pgClientImpl) bulkUpsertUser(
 
 	args := make([]interface{}, 0, 5*len(values))
 	for _, v := range values {
-		if options.UsePkey {
+		if options.UsePkey && !defaultFields.Test(UserIdFieldIndex) {
 			args = append(args, v.Id)
 		}
-		args = append(args, v.Email)
-		args = append(args, v.CreatedAt)
-		args = append(args, v.UpdatedAt)
-		args = append(args, v.DeletedAt)
+		if !defaultFields.Test(UserEmailFieldIndex) {
+			args = append(args, v.Email)
+		}
+		if !defaultFields.Test(UserCreatedAtFieldIndex) {
+			args = append(args, v.CreatedAt)
+		}
+		if !defaultFields.Test(UserUpdatedAtFieldIndex) {
+			args = append(args, v.UpdatedAt)
+		}
+		if !defaultFields.Test(UserDeletedAtFieldIndex) {
+			args = append(args, v.DeletedAt)
+		}
 	}
 
 	rows, err := p.db.QueryContext(ctx, stmt.String(), args...)

--- a/examples/timestamps/models/pggen_prelude.gen.go
+++ b/examples/timestamps/models/pggen_prelude.gen.go
@@ -15,16 +15,22 @@ import (
 	"github.com/opendoor-labs/pggen"
 )
 
+type fieldNameAndIdx struct {
+	name string
+	idx  int
+}
+
 func genBulkInsertStmt(
 	table string,
-	fields []string,
+	fields []fieldNameAndIdx,
 	nrecords int,
 	pkeyName string,
 	includeID bool,
+	defaultFieldSet pggen.FieldSet,
 ) string {
 	var ret strings.Builder
 
-	genInsertCommon(&ret, table, fields, nrecords, pkeyName, includeID)
+	genInsertCommon(&ret, table, fields, nrecords, pkeyName, includeID, defaultFieldSet)
 
 	ret.WriteString(" RETURNING \"")
 	ret.WriteString(pkeyName)
@@ -33,25 +39,25 @@ func genBulkInsertStmt(
 	return ret.String()
 }
 
-// shared between the generated upsert code and genBulkInsertStmt
 func genInsertCommon(
 	into *strings.Builder,
 	table string,
-	fields []string,
+	fields []fieldNameAndIdx,
 	nrecords int,
 	pkeyName string,
 	includeID bool,
+	defaultFieldSet pggen.FieldSet,
 ) {
 	into.WriteString("INSERT INTO ")
 	into.WriteString(table)
 	into.WriteString(" (")
 	for i, field := range fields {
-		if !includeID && field == pkeyName {
+		if (!includeID && field.name == pkeyName) || defaultFieldSet.Test(field.idx) {
 			continue
 		}
 
 		into.WriteRune('"')
-		into.WriteString(field)
+		into.WriteString(field.name)
 		into.WriteRune('"')
 		if i+1 < len(fields) {
 			into.WriteRune(',')
@@ -60,8 +66,10 @@ func genInsertCommon(
 	into.WriteString(") VALUES ")
 
 	nInsertFields := len(fields)
-	if !includeID {
-		nInsertFields--
+	for _, field := range fields {
+		if defaultFieldSet.Test(field.idx) || (!includeID && field.name == pkeyName) {
+			nInsertFields--
+		}
 	}
 
 	nextArg := 1
@@ -87,7 +95,7 @@ func genInsertCommon(
 func genUpdateStmt(
 	table string,
 	pgPkey string,
-	fields []string,
+	fields []fieldNameAndIdx,
 	fieldMask pggen.FieldSet,
 	pkeyName string,
 ) string {
@@ -102,7 +110,7 @@ func genUpdateStmt(
 	argNo := 1
 	for i, f := range fields {
 		if fieldMask.Test(i) {
-			lhs = append(lhs, f)
+			lhs = append(lhs, f.name)
 			rhs = append(rhs, fmt.Sprintf("$%d", argNo))
 			argNo++
 		}

--- a/examples/upsert/models/pggen_prelude.gen.go
+++ b/examples/upsert/models/pggen_prelude.gen.go
@@ -15,16 +15,22 @@ import (
 	"github.com/opendoor-labs/pggen"
 )
 
+type fieldNameAndIdx struct {
+	name string
+	idx  int
+}
+
 func genBulkInsertStmt(
 	table string,
-	fields []string,
+	fields []fieldNameAndIdx,
 	nrecords int,
 	pkeyName string,
 	includeID bool,
+	defaultFieldSet pggen.FieldSet,
 ) string {
 	var ret strings.Builder
 
-	genInsertCommon(&ret, table, fields, nrecords, pkeyName, includeID)
+	genInsertCommon(&ret, table, fields, nrecords, pkeyName, includeID, defaultFieldSet)
 
 	ret.WriteString(" RETURNING \"")
 	ret.WriteString(pkeyName)
@@ -33,25 +39,25 @@ func genBulkInsertStmt(
 	return ret.String()
 }
 
-// shared between the generated upsert code and genBulkInsertStmt
 func genInsertCommon(
 	into *strings.Builder,
 	table string,
-	fields []string,
+	fields []fieldNameAndIdx,
 	nrecords int,
 	pkeyName string,
 	includeID bool,
+	defaultFieldSet pggen.FieldSet,
 ) {
 	into.WriteString("INSERT INTO ")
 	into.WriteString(table)
 	into.WriteString(" (")
 	for i, field := range fields {
-		if !includeID && field == pkeyName {
+		if (!includeID && field.name == pkeyName) || defaultFieldSet.Test(field.idx) {
 			continue
 		}
 
 		into.WriteRune('"')
-		into.WriteString(field)
+		into.WriteString(field.name)
 		into.WriteRune('"')
 		if i+1 < len(fields) {
 			into.WriteRune(',')
@@ -60,8 +66,10 @@ func genInsertCommon(
 	into.WriteString(") VALUES ")
 
 	nInsertFields := len(fields)
-	if !includeID {
-		nInsertFields--
+	for _, field := range fields {
+		if defaultFieldSet.Test(field.idx) || (!includeID && field.name == pkeyName) {
+			nInsertFields--
+		}
 	}
 
 	nextArg := 1
@@ -87,7 +95,7 @@ func genInsertCommon(
 func genUpdateStmt(
 	table string,
 	pgPkey string,
-	fields []string,
+	fields []fieldNameAndIdx,
 	fieldMask pggen.FieldSet,
 	pkeyName string,
 ) string {
@@ -102,7 +110,7 @@ func genUpdateStmt(
 	argNo := 1
 	for i, f := range fields {
 		if fieldMask.Test(i) {
-			lhs = append(lhs, f)
+			lhs = append(lhs, f.name)
 			rhs = append(rhs, fmt.Sprintf("$%d", argNo))
 			argNo++
 		}

--- a/field_set.go
+++ b/field_set.go
@@ -6,9 +6,8 @@ import (
 	"github.com/willf/bitset"
 )
 
-// A bitset to use to select a subset of fields to update when calling
-// a generated Update<Entity> method. FieldSets are reference types like
-// slices or maps, so if you want to copy one, use the Clone method.
+// A bitset to use to select a subset of fields. FieldSets are reference
+// types like slices or maps, so if you want to copy one, use the Clone method.
 type FieldSet struct {
 	b *bitset.BitSet
 }
@@ -29,21 +28,41 @@ func NewFieldSetFilled(length int) FieldSet {
 
 // Deep copy the field set.
 func (fs FieldSet) Clone() FieldSet {
+	if fs.b == nil {
+		return FieldSet{}
+	}
 	return FieldSet{b: fs.b.Clone()}
 }
 
 // Set the bit at position `bit` to `value`. Can be chained.
 func (fs FieldSet) Set(bit int, value bool) FieldSet {
+	if fs.b == nil {
+		fs.b = &bitset.BitSet{}
+	}
 	fs.b.SetTo(uint(bit), value)
 	return fs
 }
 
 // Return the value of the given bit
 func (fs FieldSet) Test(bit int) bool {
+	if fs.b == nil {
+		return false
+	}
 	return fs.b.Test(uint(bit))
 }
 
 // Return the number of bits set to 1
 func (fs FieldSet) CountSetBits() int {
+	if fs.b == nil {
+		return 0
+	}
 	return int(fs.b.Count())
+}
+
+// Return the intersection of the two field sets. Equivalent of bitwise AND.
+func (fs FieldSet) Intersection(rhs FieldSet) FieldSet {
+	if fs.b == nil || rhs.b == nil {
+		return FieldSet{}
+	}
+	return FieldSet{b: fs.b.Intersection(rhs.b)}
 }

--- a/options.go
+++ b/options.go
@@ -4,7 +4,8 @@ package pggen
 
 type InsertOpt func(opts *InsertOptions)
 type InsertOptions struct {
-	UsePkey bool
+	UsePkey       bool
+	DefaultFields FieldSet
 }
 
 // InsertUsePkey tells an insert method to insert the primary key into the database
@@ -14,9 +15,20 @@ func InsertUsePkey(opts *InsertOptions) {
 	opts.UsePkey = true
 }
 
+// Set the fields that will be generated from the default values stored in the database.
+// By default, all field values are inserted based on the provided struct.
+// If all fields are specified, only those fields which actually have a default in the
+// database are defaulted, other fields are inserted as normal.
+func InsertDefaultFields(fieldSet FieldSet) InsertOpt {
+	return func(opts *InsertOptions) {
+		opts.DefaultFields = fieldSet
+	}
+}
+
 type UpsertOpt func(opts *UpsertOptions)
 type UpsertOptions struct {
-	UsePkey bool
+	UsePkey       bool
+	DefaultFields FieldSet
 }
 
 // UpsertUsePkey tells an upsert method to insert the primary key into the database
@@ -24,6 +36,16 @@ type UpsertOptions struct {
 // as is the default.
 func UpsertUsePkey(opts *UpsertOptions) {
 	opts.UsePkey = true
+}
+
+// Set the fields that will be generated from the default values stored in the database.
+// By default, all field values are inserted based on the provided struct.
+// If all fields are specified, only those fields which actually have a default in the
+// database are defaulted, other fields are inserted as normal.
+func UpsertDefaultFields(fieldSet FieldSet) UpsertOpt {
+	return func(opts *UpsertOptions) {
+		opts.DefaultFields = fieldSet
+	}
 }
 
 type GetOpt func(opts *GetOptions)


### PR DESCRIPTION
This patch teaches the generated insert and upsert methods
about a new functional configuration option for both the insert
and upsert methods. This option allows you to specify a set of
fields which should have their values pulled from the defaults
specified in the database table definition. Hopefully this will
encourage people to lean on the database for defaults a little
more.