### PR TITLE
validate import strings

### DIFF
--- a/cmd/pggen/test/cli_test.go
+++ b/cmd/pggen/test/cli_test.go
@@ -312,6 +312,14 @@ require_query_comments = true
 		exitCode: 1,
 		stderrRE: `cannot have a json type`,
 	},
+	{
+		toml: `
+[[type_override]]
+	pkg = "github.com/opendoor-labs/pggen/examples/query/models" # note lack of quotes
+		`,
+		exitCode: 1,
+		stderrRE: `import paths without spaces in them should be quoted strings`,
+	},
 }
 
 func TestCLI(t *testing.T) {

--- a/gen/gen.go
+++ b/gen/gen.go
@@ -263,6 +263,10 @@ func (g *Generator) setupGenEnv() (*config.DbConfig, error) {
 	if err != nil {
 		return nil, err
 	}
+	err = conf.Validate()
+	if err != nil {
+		return nil, err
+	}
 
 	err = g.typeResolver.Resolve(&conf)
 	if err != nil {

--- a/gen/internal/names/import_paths.go
+++ b/gen/internal/names/import_paths.go
@@ -1,0 +1,29 @@
+package names
+
+// file: import_paths.go
+// This file contains code to validate go import paths. Those are sort of names right?
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+var quotedStringRE = regexp.MustCompile(`^"[^"]+"$`)
+var aliasedQuotedStringRE = regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9]*\s+"[^"]+"$`)
+
+// ValidateImportPath checks the given path for issues and
+// returns an error if it finds any.
+func ValidateImportPath(path string) error {
+	if strings.IndexByte(path, ' ') == -1 {
+		if !quotedStringRE.Match([]byte(path)) {
+			return fmt.Errorf("import paths without spaces in them should be quoted strings")
+		}
+	} else if !aliasedQuotedStringRE.Match([]byte(path)) {
+		// if there is a space in the path it should be an identifier followed
+		// by a quoted string.
+		return fmt.Errorf("import paths containing spaces should be aliased quoted strings")
+	}
+
+	return nil
+}

--- a/gen/internal/names/import_paths_test.go
+++ b/gen/internal/names/import_paths_test.go
@@ -1,0 +1,75 @@
+package names
+
+import (
+	"regexp"
+	"testing"
+)
+
+func TestValidateImportPath(t *testing.T) {
+	type testCase struct {
+		in    string
+		errRE string
+	}
+
+	cases := []testCase{
+		{
+			in: `"foo"`,
+		},
+		{
+			in: `blip "foo"`,
+		},
+		{
+			in:    `"foo`,
+			errRE: "import paths without spaces in them should be quoted strings",
+		},
+		{
+			in:    `foo`,
+			errRE: "import paths without spaces in them should be quoted strings",
+		},
+		{
+			in:    ``,
+			errRE: "import paths without spaces in them should be quoted strings",
+		},
+		{
+			in:    `foo"`,
+			errRE: "import paths without spaces in them should be quoted strings",
+		},
+		{
+			in:    `"foo" "bar"`,
+			errRE: "import paths containing spaces should be aliased quoted strings",
+		},
+		{
+			in:    `9oo "bar"`,
+			errRE: "import paths containing spaces should be aliased quoted strings",
+		},
+		{
+			in:    `oo bar"`,
+			errRE: "import paths containing spaces should be aliased quoted strings",
+		},
+		{
+			in:    `oo b"ar"`,
+			errRE: "import paths containing spaces should be aliased quoted strings",
+		},
+	}
+
+	for i, c := range cases {
+		err := ValidateImportPath(c.in)
+		if len(c.errRE) > 0 {
+			if err == nil {
+				t.Fatalf("%d: no error, but we were expecting one", i)
+			}
+
+			matches, reErr := regexp.Match(c.errRE, []byte(err.Error()))
+			if reErr != nil {
+				t.Fatalf("%d: regex err: %s", i, reErr.Error())
+			}
+			if !matches {
+				t.Fatalf("%d: /%s/ failed to match error '%s'", i, c.errRE, err.Error())
+			}
+		} else {
+			if err != nil {
+				t.Fatalf("%d: unexpected err: %s", i, err.Error())
+			}
+		}
+	}
+}


### PR DESCRIPTION
Previously specifying import strings for type overrides and
json types was a little bit fraught because if you did not
get the format right it could cause an internal error when
we went to gofmt the code before landing it on disk.

This patch fixes that by adding a validation step right
after the config file is read in.