### PR TITLE
add ConnPGClient

### DIFF
--- a/cmd/pggen/test/conn_test.go
+++ b/cmd/pggen/test/conn_test.go
@@ -1,0 +1,21 @@
+package test
+
+import (
+	"github.com/opendoor-labs/pggen/cmd/pggen/test/models"
+	"testing"
+)
+
+func TestConnSmoke(t *testing.T) {
+	connClient, err := pgClient.Conn(ctx)
+	chkErr(t, err)
+
+	id, err := connClient.InsertSmallEntity(ctx, &models.SmallEntity{
+		Anint: 9735,
+	})
+	chkErr(t, err)
+	entity, err := connClient.GetSmallEntity(ctx, id)
+	chkErr(t, err)
+	if entity.Anint != 9735 {
+		t.Fatal("bad value")
+	}
+}

--- a/examples/json_columns/models/models.gen.go
+++ b/examples/json_columns/models/models.gen.go
@@ -71,6 +71,15 @@ func (p *PGClient) BeginTx(ctx context.Context, opts *sql.TxOptions) (*TxPGClien
 	}, nil
 }
 
+func (p *PGClient) Conn(ctx context.Context) (*ConnPGClient, error) {
+	conn, err := p.topLevelDB.Conn(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ConnPGClient{impl: pgClientImpl{db: conn, client: p}}, nil
+}
+
 // A postgres client that operates within a transaction. Supports all the same
 // generated methods that PGClient does.
 type TxPGClient struct {
@@ -87,6 +96,18 @@ func (tx *TxPGClient) Rollback() error {
 
 func (tx *TxPGClient) Commit() error {
 	return tx.impl.db.(*sql.Tx).Commit()
+}
+
+type ConnPGClient struct {
+	impl pgClientImpl
+}
+
+func (conn *ConnPGClient) Close() error {
+	return conn.impl.db.(*sql.Conn).Close()
+}
+
+func (conn *ConnPGClient) Handle() pggen.DBHandle {
+	return conn.impl.db
 }
 
 // A database client that can wrap either a direct database connection or a transaction
@@ -109,6 +130,13 @@ func (tx *TxPGClient) GetUser(
 	opts ...pggen.GetOpt,
 ) (*User, error) {
 	return tx.impl.getUser(ctx, id)
+}
+func (conn *ConnPGClient) GetUser(
+	ctx context.Context,
+	id int64,
+	opts ...pggen.GetOpt,
+) (*User, error) {
+	return conn.impl.getUser(ctx, id)
 }
 func (p *pgClientImpl) getUser(
 	ctx context.Context,
@@ -138,6 +166,13 @@ func (tx *TxPGClient) ListUser(
 	opts ...pggen.ListOpt,
 ) (ret []User, err error) {
 	return tx.impl.listUser(ctx, ids, false /* isGet */)
+}
+func (conn *ConnPGClient) ListUser(
+	ctx context.Context,
+	ids []int64,
+	opts ...pggen.ListOpt,
+) (ret []User, err error) {
+	return conn.impl.listUser(ctx, ids, false /* isGet */)
 }
 func (p *pgClientImpl) listUser(
 	ctx context.Context,
@@ -222,6 +257,16 @@ func (tx *TxPGClient) InsertUser(
 
 // Insert a User into the database. Returns the primary
 // key of the inserted row.
+func (conn *ConnPGClient) InsertUser(
+	ctx context.Context,
+	value *User,
+	opts ...pggen.InsertOpt,
+) (ret int64, err error) {
+	return conn.impl.insertUser(ctx, value, opts...)
+}
+
+// Insert a User into the database. Returns the primary
+// key of the inserted row.
 func (p *pgClientImpl) insertUser(
 	ctx context.Context,
 	value *User,
@@ -260,6 +305,16 @@ func (tx *TxPGClient) BulkInsertUser(
 	opts ...pggen.InsertOpt,
 ) ([]int64, error) {
 	return tx.impl.bulkInsertUser(ctx, values, opts...)
+}
+
+// Insert a list of User. Returns a list of the primary keys of
+// the inserted rows.
+func (conn *ConnPGClient) BulkInsertUser(
+	ctx context.Context,
+	values []User,
+	opts ...pggen.InsertOpt,
+) ([]int64, error) {
+	return conn.impl.bulkInsertUser(ctx, values, opts...)
 }
 
 // Insert a list of User. Returns a list of the primary keys of
@@ -381,6 +436,20 @@ func (tx *TxPGClient) UpdateUser(
 ) (ret int64, err error) {
 	return tx.impl.updateUser(ctx, value, fieldMask)
 }
+
+// Update a User. 'value' must at the least have
+// a primary key set. The 'fieldMask' field set indicates which fields
+// should be updated in the database.
+//
+// Returns the primary key of the updated row.
+func (conn *ConnPGClient) UpdateUser(
+	ctx context.Context,
+	value *User,
+	fieldMask pggen.FieldSet,
+	opts ...pggen.UpdateOpt,
+) (ret int64, err error) {
+	return conn.impl.updateUser(ctx, value, fieldMask)
+}
 func (p *pgClientImpl) updateUser(
 	ctx context.Context,
 	value *User,
@@ -478,6 +547,30 @@ func (tx *TxPGClient) UpsertUser(
 	return value.Id, nil
 }
 
+// Upsert a User value. If the given value conflicts with
+// an existing row in the database, use the provided value to update that row
+// rather than inserting it. Only the fields specified by 'fieldMask' are
+// actually updated. All other fields are left as-is.
+func (conn *ConnPGClient) UpsertUser(
+	ctx context.Context,
+	value *User,
+	constraintNames []string,
+	fieldMask pggen.FieldSet,
+	opts ...pggen.UpsertOpt,
+) (ret int64, err error) {
+	var val []int64
+	val, err = conn.impl.bulkUpsertUser(ctx, []User{*value}, constraintNames, fieldMask, opts...)
+	if err != nil {
+		return
+	}
+	if len(val) == 1 {
+		return val[0], nil
+	}
+
+	// only possible if no upsert fields were specified by the field mask
+	return value.Id, nil
+}
+
 // Upsert a set of User values. If any of the given values conflict with
 // existing rows in the database, use the provided values to update the rows which
 // exist in the database rather than inserting them. Only the fields specified by
@@ -504,6 +597,20 @@ func (tx *TxPGClient) BulkUpsertUser(
 	opts ...pggen.UpsertOpt,
 ) (ret []int64, err error) {
 	return tx.impl.bulkUpsertUser(ctx, values, constraintNames, fieldMask, opts...)
+}
+
+// Upsert a set of User values. If any of the given values conflict with
+// existing rows in the database, use the provided values to update the rows which
+// exist in the database rather than inserting them. Only the fields specified by
+// 'fieldMask' are actually updated. All other fields are left as-is.
+func (conn *ConnPGClient) BulkUpsertUser(
+	ctx context.Context,
+	values []User,
+	constraintNames []string,
+	fieldMask pggen.FieldSet,
+	opts ...pggen.UpsertOpt,
+) (ret []int64, err error) {
+	return conn.impl.bulkUpsertUser(ctx, values, constraintNames, fieldMask, opts...)
 }
 func (p *pgClientImpl) bulkUpsertUser(
 	ctx context.Context,
@@ -642,6 +749,13 @@ func (tx *TxPGClient) DeleteUser(
 ) error {
 	return tx.impl.bulkDeleteUser(ctx, []int64{id}, opts...)
 }
+func (conn *ConnPGClient) DeleteUser(
+	ctx context.Context,
+	id int64,
+	opts ...pggen.DeleteOpt,
+) error {
+	return conn.impl.bulkDeleteUser(ctx, []int64{id}, opts...)
+}
 
 func (p *PGClient) BulkDeleteUser(
 	ctx context.Context,
@@ -656,6 +770,13 @@ func (tx *TxPGClient) BulkDeleteUser(
 	opts ...pggen.DeleteOpt,
 ) error {
 	return tx.impl.bulkDeleteUser(ctx, ids, opts...)
+}
+func (conn *ConnPGClient) BulkDeleteUser(
+	ctx context.Context,
+	ids []int64,
+	opts ...pggen.DeleteOpt,
+) error {
+	return conn.impl.bulkDeleteUser(ctx, ids, opts...)
 }
 func (p *pgClientImpl) bulkDeleteUser(
 	ctx context.Context,
@@ -715,6 +836,14 @@ func (tx *TxPGClient) UserFillIncludes(
 ) error {
 	return tx.impl.privateUserBulkFillIncludes(ctx, []*User{rec}, includes)
 }
+func (conn *ConnPGClient) UserFillIncludes(
+	ctx context.Context,
+	rec *User,
+	includes *include.Spec,
+	opts ...pggen.IncludeOpt,
+) error {
+	return conn.impl.privateUserBulkFillIncludes(ctx, []*User{rec}, includes)
+}
 
 func (p *PGClient) UserBulkFillIncludes(
 	ctx context.Context,
@@ -731,6 +860,14 @@ func (tx *TxPGClient) UserBulkFillIncludes(
 	opts ...pggen.IncludeOpt,
 ) error {
 	return tx.impl.privateUserBulkFillIncludes(ctx, recs, includes)
+}
+func (conn *ConnPGClient) UserBulkFillIncludes(
+	ctx context.Context,
+	recs []*User,
+	includes *include.Spec,
+	opts ...pggen.IncludeOpt,
+) error {
+	return conn.impl.privateUserBulkFillIncludes(ctx, recs, includes)
 }
 func (p *pgClientImpl) privateUserBulkFillIncludes(
 	ctx context.Context,

--- a/examples/middleware/models/models.gen.go
+++ b/examples/middleware/models/models.gen.go
@@ -68,6 +68,15 @@ func (p *PGClient) BeginTx(ctx context.Context, opts *sql.TxOptions) (*TxPGClien
 	}, nil
 }
 
+func (p *PGClient) Conn(ctx context.Context) (*ConnPGClient, error) {
+	conn, err := p.topLevelDB.Conn(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ConnPGClient{impl: pgClientImpl{db: conn, client: p}}, nil
+}
+
 // A postgres client that operates within a transaction. Supports all the same
 // generated methods that PGClient does.
 type TxPGClient struct {
@@ -84,6 +93,18 @@ func (tx *TxPGClient) Rollback() error {
 
 func (tx *TxPGClient) Commit() error {
 	return tx.impl.db.(*sql.Tx).Commit()
+}
+
+type ConnPGClient struct {
+	impl pgClientImpl
+}
+
+func (conn *ConnPGClient) Close() error {
+	return conn.impl.db.(*sql.Conn).Close()
+}
+
+func (conn *ConnPGClient) Handle() pggen.DBHandle {
+	return conn.impl.db
 }
 
 // A database client that can wrap either a direct database connection or a transaction
@@ -106,6 +127,13 @@ func (tx *TxPGClient) GetFoo(
 	opts ...pggen.GetOpt,
 ) (*Foo, error) {
 	return tx.impl.getFoo(ctx, id)
+}
+func (conn *ConnPGClient) GetFoo(
+	ctx context.Context,
+	id int64,
+	opts ...pggen.GetOpt,
+) (*Foo, error) {
+	return conn.impl.getFoo(ctx, id)
 }
 func (p *pgClientImpl) getFoo(
 	ctx context.Context,
@@ -135,6 +163,13 @@ func (tx *TxPGClient) ListFoo(
 	opts ...pggen.ListOpt,
 ) (ret []Foo, err error) {
 	return tx.impl.listFoo(ctx, ids, false /* isGet */)
+}
+func (conn *ConnPGClient) ListFoo(
+	ctx context.Context,
+	ids []int64,
+	opts ...pggen.ListOpt,
+) (ret []Foo, err error) {
+	return conn.impl.listFoo(ctx, ids, false /* isGet */)
 }
 func (p *pgClientImpl) listFoo(
 	ctx context.Context,
@@ -219,6 +254,16 @@ func (tx *TxPGClient) InsertFoo(
 
 // Insert a Foo into the database. Returns the primary
 // key of the inserted row.
+func (conn *ConnPGClient) InsertFoo(
+	ctx context.Context,
+	value *Foo,
+	opts ...pggen.InsertOpt,
+) (ret int64, err error) {
+	return conn.impl.insertFoo(ctx, value, opts...)
+}
+
+// Insert a Foo into the database. Returns the primary
+// key of the inserted row.
 func (p *pgClientImpl) insertFoo(
 	ctx context.Context,
 	value *Foo,
@@ -257,6 +302,16 @@ func (tx *TxPGClient) BulkInsertFoo(
 	opts ...pggen.InsertOpt,
 ) ([]int64, error) {
 	return tx.impl.bulkInsertFoo(ctx, values, opts...)
+}
+
+// Insert a list of Foo. Returns a list of the primary keys of
+// the inserted rows.
+func (conn *ConnPGClient) BulkInsertFoo(
+	ctx context.Context,
+	values []Foo,
+	opts ...pggen.InsertOpt,
+) ([]int64, error) {
+	return conn.impl.bulkInsertFoo(ctx, values, opts...)
 }
 
 // Insert a list of Foo. Returns a list of the primary keys of
@@ -363,6 +418,20 @@ func (tx *TxPGClient) UpdateFoo(
 ) (ret int64, err error) {
 	return tx.impl.updateFoo(ctx, value, fieldMask)
 }
+
+// Update a Foo. 'value' must at the least have
+// a primary key set. The 'fieldMask' field set indicates which fields
+// should be updated in the database.
+//
+// Returns the primary key of the updated row.
+func (conn *ConnPGClient) UpdateFoo(
+	ctx context.Context,
+	value *Foo,
+	fieldMask pggen.FieldSet,
+	opts ...pggen.UpdateOpt,
+) (ret int64, err error) {
+	return conn.impl.updateFoo(ctx, value, fieldMask)
+}
 func (p *pgClientImpl) updateFoo(
 	ctx context.Context,
 	value *Foo,
@@ -451,6 +520,30 @@ func (tx *TxPGClient) UpsertFoo(
 	return value.Id, nil
 }
 
+// Upsert a Foo value. If the given value conflicts with
+// an existing row in the database, use the provided value to update that row
+// rather than inserting it. Only the fields specified by 'fieldMask' are
+// actually updated. All other fields are left as-is.
+func (conn *ConnPGClient) UpsertFoo(
+	ctx context.Context,
+	value *Foo,
+	constraintNames []string,
+	fieldMask pggen.FieldSet,
+	opts ...pggen.UpsertOpt,
+) (ret int64, err error) {
+	var val []int64
+	val, err = conn.impl.bulkUpsertFoo(ctx, []Foo{*value}, constraintNames, fieldMask, opts...)
+	if err != nil {
+		return
+	}
+	if len(val) == 1 {
+		return val[0], nil
+	}
+
+	// only possible if no upsert fields were specified by the field mask
+	return value.Id, nil
+}
+
 // Upsert a set of Foo values. If any of the given values conflict with
 // existing rows in the database, use the provided values to update the rows which
 // exist in the database rather than inserting them. Only the fields specified by
@@ -477,6 +570,20 @@ func (tx *TxPGClient) BulkUpsertFoo(
 	opts ...pggen.UpsertOpt,
 ) (ret []int64, err error) {
 	return tx.impl.bulkUpsertFoo(ctx, values, constraintNames, fieldMask, opts...)
+}
+
+// Upsert a set of Foo values. If any of the given values conflict with
+// existing rows in the database, use the provided values to update the rows which
+// exist in the database rather than inserting them. Only the fields specified by
+// 'fieldMask' are actually updated. All other fields are left as-is.
+func (conn *ConnPGClient) BulkUpsertFoo(
+	ctx context.Context,
+	values []Foo,
+	constraintNames []string,
+	fieldMask pggen.FieldSet,
+	opts ...pggen.UpsertOpt,
+) (ret []int64, err error) {
+	return conn.impl.bulkUpsertFoo(ctx, values, constraintNames, fieldMask, opts...)
 }
 func (p *pgClientImpl) bulkUpsertFoo(
 	ctx context.Context,
@@ -594,6 +701,13 @@ func (tx *TxPGClient) DeleteFoo(
 ) error {
 	return tx.impl.bulkDeleteFoo(ctx, []int64{id}, opts...)
 }
+func (conn *ConnPGClient) DeleteFoo(
+	ctx context.Context,
+	id int64,
+	opts ...pggen.DeleteOpt,
+) error {
+	return conn.impl.bulkDeleteFoo(ctx, []int64{id}, opts...)
+}
 
 func (p *PGClient) BulkDeleteFoo(
 	ctx context.Context,
@@ -608,6 +722,13 @@ func (tx *TxPGClient) BulkDeleteFoo(
 	opts ...pggen.DeleteOpt,
 ) error {
 	return tx.impl.bulkDeleteFoo(ctx, ids, opts...)
+}
+func (conn *ConnPGClient) BulkDeleteFoo(
+	ctx context.Context,
+	ids []int64,
+	opts ...pggen.DeleteOpt,
+) error {
+	return conn.impl.bulkDeleteFoo(ctx, ids, opts...)
 }
 func (p *pgClientImpl) bulkDeleteFoo(
 	ctx context.Context,
@@ -667,6 +788,14 @@ func (tx *TxPGClient) FooFillIncludes(
 ) error {
 	return tx.impl.privateFooBulkFillIncludes(ctx, []*Foo{rec}, includes)
 }
+func (conn *ConnPGClient) FooFillIncludes(
+	ctx context.Context,
+	rec *Foo,
+	includes *include.Spec,
+	opts ...pggen.IncludeOpt,
+) error {
+	return conn.impl.privateFooBulkFillIncludes(ctx, []*Foo{rec}, includes)
+}
 
 func (p *PGClient) FooBulkFillIncludes(
 	ctx context.Context,
@@ -683,6 +812,14 @@ func (tx *TxPGClient) FooBulkFillIncludes(
 	opts ...pggen.IncludeOpt,
 ) error {
 	return tx.impl.privateFooBulkFillIncludes(ctx, recs, includes)
+}
+func (conn *ConnPGClient) FooBulkFillIncludes(
+	ctx context.Context,
+	recs []*Foo,
+	includes *include.Spec,
+	opts ...pggen.IncludeOpt,
+) error {
+	return conn.impl.privateFooBulkFillIncludes(ctx, recs, includes)
 }
 func (p *pgClientImpl) privateFooBulkFillIncludes(
 	ctx context.Context,

--- a/examples/query_argument_names/models/models.gen.go
+++ b/examples/query_argument_names/models/models.gen.go
@@ -70,6 +70,15 @@ func (p *PGClient) BeginTx(ctx context.Context, opts *sql.TxOptions) (*TxPGClien
 	}, nil
 }
 
+func (p *PGClient) Conn(ctx context.Context) (*ConnPGClient, error) {
+	conn, err := p.topLevelDB.Conn(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ConnPGClient{impl: pgClientImpl{db: conn, client: p}}, nil
+}
+
 // A postgres client that operates within a transaction. Supports all the same
 // generated methods that PGClient does.
 type TxPGClient struct {
@@ -86,6 +95,18 @@ func (tx *TxPGClient) Rollback() error {
 
 func (tx *TxPGClient) Commit() error {
 	return tx.impl.db.(*sql.Tx).Commit()
+}
+
+type ConnPGClient struct {
+	impl pgClientImpl
+}
+
+func (conn *ConnPGClient) Close() error {
+	return conn.impl.db.(*sql.Conn).Close()
+}
+
+func (conn *ConnPGClient) Handle() pggen.DBHandle {
+	return conn.impl.db
 }
 
 // A database client that can wrap either a direct database connection or a transaction
@@ -108,6 +129,13 @@ func (tx *TxPGClient) GetUser(
 	opts ...pggen.GetOpt,
 ) (*User, error) {
 	return tx.impl.getUser(ctx, id)
+}
+func (conn *ConnPGClient) GetUser(
+	ctx context.Context,
+	id int64,
+	opts ...pggen.GetOpt,
+) (*User, error) {
+	return conn.impl.getUser(ctx, id)
 }
 func (p *pgClientImpl) getUser(
 	ctx context.Context,
@@ -137,6 +165,13 @@ func (tx *TxPGClient) ListUser(
 	opts ...pggen.ListOpt,
 ) (ret []User, err error) {
 	return tx.impl.listUser(ctx, ids, false /* isGet */)
+}
+func (conn *ConnPGClient) ListUser(
+	ctx context.Context,
+	ids []int64,
+	opts ...pggen.ListOpt,
+) (ret []User, err error) {
+	return conn.impl.listUser(ctx, ids, false /* isGet */)
 }
 func (p *pgClientImpl) listUser(
 	ctx context.Context,
@@ -221,6 +256,16 @@ func (tx *TxPGClient) InsertUser(
 
 // Insert a User into the database. Returns the primary
 // key of the inserted row.
+func (conn *ConnPGClient) InsertUser(
+	ctx context.Context,
+	value *User,
+	opts ...pggen.InsertOpt,
+) (ret int64, err error) {
+	return conn.impl.insertUser(ctx, value, opts...)
+}
+
+// Insert a User into the database. Returns the primary
+// key of the inserted row.
 func (p *pgClientImpl) insertUser(
 	ctx context.Context,
 	value *User,
@@ -259,6 +304,16 @@ func (tx *TxPGClient) BulkInsertUser(
 	opts ...pggen.InsertOpt,
 ) ([]int64, error) {
 	return tx.impl.bulkInsertUser(ctx, values, opts...)
+}
+
+// Insert a list of User. Returns a list of the primary keys of
+// the inserted rows.
+func (conn *ConnPGClient) BulkInsertUser(
+	ctx context.Context,
+	values []User,
+	opts ...pggen.InsertOpt,
+) ([]int64, error) {
+	return conn.impl.bulkInsertUser(ctx, values, opts...)
 }
 
 // Insert a list of User. Returns a list of the primary keys of
@@ -370,6 +425,20 @@ func (tx *TxPGClient) UpdateUser(
 ) (ret int64, err error) {
 	return tx.impl.updateUser(ctx, value, fieldMask)
 }
+
+// Update a User. 'value' must at the least have
+// a primary key set. The 'fieldMask' field set indicates which fields
+// should be updated in the database.
+//
+// Returns the primary key of the updated row.
+func (conn *ConnPGClient) UpdateUser(
+	ctx context.Context,
+	value *User,
+	fieldMask pggen.FieldSet,
+	opts ...pggen.UpdateOpt,
+) (ret int64, err error) {
+	return conn.impl.updateUser(ctx, value, fieldMask)
+}
 func (p *pgClientImpl) updateUser(
 	ctx context.Context,
 	value *User,
@@ -461,6 +530,30 @@ func (tx *TxPGClient) UpsertUser(
 	return value.Id, nil
 }
 
+// Upsert a User value. If the given value conflicts with
+// an existing row in the database, use the provided value to update that row
+// rather than inserting it. Only the fields specified by 'fieldMask' are
+// actually updated. All other fields are left as-is.
+func (conn *ConnPGClient) UpsertUser(
+	ctx context.Context,
+	value *User,
+	constraintNames []string,
+	fieldMask pggen.FieldSet,
+	opts ...pggen.UpsertOpt,
+) (ret int64, err error) {
+	var val []int64
+	val, err = conn.impl.bulkUpsertUser(ctx, []User{*value}, constraintNames, fieldMask, opts...)
+	if err != nil {
+		return
+	}
+	if len(val) == 1 {
+		return val[0], nil
+	}
+
+	// only possible if no upsert fields were specified by the field mask
+	return value.Id, nil
+}
+
 // Upsert a set of User values. If any of the given values conflict with
 // existing rows in the database, use the provided values to update the rows which
 // exist in the database rather than inserting them. Only the fields specified by
@@ -487,6 +580,20 @@ func (tx *TxPGClient) BulkUpsertUser(
 	opts ...pggen.UpsertOpt,
 ) (ret []int64, err error) {
 	return tx.impl.bulkUpsertUser(ctx, values, constraintNames, fieldMask, opts...)
+}
+
+// Upsert a set of User values. If any of the given values conflict with
+// existing rows in the database, use the provided values to update the rows which
+// exist in the database rather than inserting them. Only the fields specified by
+// 'fieldMask' are actually updated. All other fields are left as-is.
+func (conn *ConnPGClient) BulkUpsertUser(
+	ctx context.Context,
+	values []User,
+	constraintNames []string,
+	fieldMask pggen.FieldSet,
+	opts ...pggen.UpsertOpt,
+) (ret []int64, err error) {
+	return conn.impl.bulkUpsertUser(ctx, values, constraintNames, fieldMask, opts...)
 }
 func (p *pgClientImpl) bulkUpsertUser(
 	ctx context.Context,
@@ -611,6 +718,13 @@ func (tx *TxPGClient) DeleteUser(
 ) error {
 	return tx.impl.bulkDeleteUser(ctx, []int64{id}, opts...)
 }
+func (conn *ConnPGClient) DeleteUser(
+	ctx context.Context,
+	id int64,
+	opts ...pggen.DeleteOpt,
+) error {
+	return conn.impl.bulkDeleteUser(ctx, []int64{id}, opts...)
+}
 
 func (p *PGClient) BulkDeleteUser(
 	ctx context.Context,
@@ -625,6 +739,13 @@ func (tx *TxPGClient) BulkDeleteUser(
 	opts ...pggen.DeleteOpt,
 ) error {
 	return tx.impl.bulkDeleteUser(ctx, ids, opts...)
+}
+func (conn *ConnPGClient) BulkDeleteUser(
+	ctx context.Context,
+	ids []int64,
+	opts ...pggen.DeleteOpt,
+) error {
+	return conn.impl.bulkDeleteUser(ctx, ids, opts...)
 }
 func (p *pgClientImpl) bulkDeleteUser(
 	ctx context.Context,
@@ -684,6 +805,14 @@ func (tx *TxPGClient) UserFillIncludes(
 ) error {
 	return tx.impl.privateUserBulkFillIncludes(ctx, []*User{rec}, includes)
 }
+func (conn *ConnPGClient) UserFillIncludes(
+	ctx context.Context,
+	rec *User,
+	includes *include.Spec,
+	opts ...pggen.IncludeOpt,
+) error {
+	return conn.impl.privateUserBulkFillIncludes(ctx, []*User{rec}, includes)
+}
 
 func (p *PGClient) UserBulkFillIncludes(
 	ctx context.Context,
@@ -700,6 +829,14 @@ func (tx *TxPGClient) UserBulkFillIncludes(
 	opts ...pggen.IncludeOpt,
 ) error {
 	return tx.impl.privateUserBulkFillIncludes(ctx, recs, includes)
+}
+func (conn *ConnPGClient) UserBulkFillIncludes(
+	ctx context.Context,
+	recs []*User,
+	includes *include.Spec,
+	opts ...pggen.IncludeOpt,
+) error {
+	return conn.impl.privateUserBulkFillIncludes(ctx, recs, includes)
 }
 func (p *pgClientImpl) privateUserBulkFillIncludes(
 	ctx context.Context,
@@ -768,6 +905,18 @@ func (tx *TxPGClient) GetUserByEmailOrNickname(
 		nickname,
 	)
 }
+
+func (conn *ConnPGClient) GetUserByEmailOrNickname(
+	ctx context.Context,
+	email string,
+	nickname string,
+) (ret []User, err error) {
+	return conn.impl.GetUserByEmailOrNickname(
+		ctx,
+		email,
+		nickname,
+	)
+}
 func (p *pgClientImpl) GetUserByEmailOrNickname(
 	ctx context.Context,
 	email string,
@@ -830,6 +979,18 @@ func (tx *TxPGClient) GetUserByEmailOrNicknameQuery(
 		nickname,
 	)
 }
+
+func (conn *ConnPGClient) GetUserByEmailOrNicknameQuery(
+	ctx context.Context,
+	email string,
+	nickname string,
+) (*sql.Rows, error) {
+	return conn.impl.GetUserByEmailOrNicknameQuery(
+		ctx,
+		email,
+		nickname,
+	)
+}
 func (p *pgClientImpl) GetUserByEmailOrNicknameQuery(
 	ctx context.Context,
 	email string,
@@ -857,6 +1018,15 @@ func (tx *TxPGClient) DeleteUsersByNickname(
 	nickname string,
 ) (sql.Result, error) {
 	return tx.impl.DeleteUsersByNickname(
+		ctx,
+		nickname,
+	)
+}
+func (conn *ConnPGClient) DeleteUsersByNickname(
+	ctx context.Context,
+	nickname string,
+) (sql.Result, error) {
+	return conn.impl.DeleteUsersByNickname(
 		ctx,
 		nickname,
 	)

--- a/examples/single_results/models/models.gen.go
+++ b/examples/single_results/models/models.gen.go
@@ -70,6 +70,15 @@ func (p *PGClient) BeginTx(ctx context.Context, opts *sql.TxOptions) (*TxPGClien
 	}, nil
 }
 
+func (p *PGClient) Conn(ctx context.Context) (*ConnPGClient, error) {
+	conn, err := p.topLevelDB.Conn(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ConnPGClient{impl: pgClientImpl{db: conn, client: p}}, nil
+}
+
 // A postgres client that operates within a transaction. Supports all the same
 // generated methods that PGClient does.
 type TxPGClient struct {
@@ -86,6 +95,18 @@ func (tx *TxPGClient) Rollback() error {
 
 func (tx *TxPGClient) Commit() error {
 	return tx.impl.db.(*sql.Tx).Commit()
+}
+
+type ConnPGClient struct {
+	impl pgClientImpl
+}
+
+func (conn *ConnPGClient) Close() error {
+	return conn.impl.db.(*sql.Conn).Close()
+}
+
+func (conn *ConnPGClient) Handle() pggen.DBHandle {
+	return conn.impl.db
 }
 
 // A database client that can wrap either a direct database connection or a transaction
@@ -108,6 +129,13 @@ func (tx *TxPGClient) GetFoo(
 	opts ...pggen.GetOpt,
 ) (*Foo, error) {
 	return tx.impl.getFoo(ctx, id)
+}
+func (conn *ConnPGClient) GetFoo(
+	ctx context.Context,
+	id int64,
+	opts ...pggen.GetOpt,
+) (*Foo, error) {
+	return conn.impl.getFoo(ctx, id)
 }
 func (p *pgClientImpl) getFoo(
 	ctx context.Context,
@@ -137,6 +165,13 @@ func (tx *TxPGClient) ListFoo(
 	opts ...pggen.ListOpt,
 ) (ret []Foo, err error) {
 	return tx.impl.listFoo(ctx, ids, false /* isGet */)
+}
+func (conn *ConnPGClient) ListFoo(
+	ctx context.Context,
+	ids []int64,
+	opts ...pggen.ListOpt,
+) (ret []Foo, err error) {
+	return conn.impl.listFoo(ctx, ids, false /* isGet */)
 }
 func (p *pgClientImpl) listFoo(
 	ctx context.Context,
@@ -221,6 +256,16 @@ func (tx *TxPGClient) InsertFoo(
 
 // Insert a Foo into the database. Returns the primary
 // key of the inserted row.
+func (conn *ConnPGClient) InsertFoo(
+	ctx context.Context,
+	value *Foo,
+	opts ...pggen.InsertOpt,
+) (ret int64, err error) {
+	return conn.impl.insertFoo(ctx, value, opts...)
+}
+
+// Insert a Foo into the database. Returns the primary
+// key of the inserted row.
 func (p *pgClientImpl) insertFoo(
 	ctx context.Context,
 	value *Foo,
@@ -259,6 +304,16 @@ func (tx *TxPGClient) BulkInsertFoo(
 	opts ...pggen.InsertOpt,
 ) ([]int64, error) {
 	return tx.impl.bulkInsertFoo(ctx, values, opts...)
+}
+
+// Insert a list of Foo. Returns a list of the primary keys of
+// the inserted rows.
+func (conn *ConnPGClient) BulkInsertFoo(
+	ctx context.Context,
+	values []Foo,
+	opts ...pggen.InsertOpt,
+) ([]int64, error) {
+	return conn.impl.bulkInsertFoo(ctx, values, opts...)
 }
 
 // Insert a list of Foo. Returns a list of the primary keys of
@@ -365,6 +420,20 @@ func (tx *TxPGClient) UpdateFoo(
 ) (ret int64, err error) {
 	return tx.impl.updateFoo(ctx, value, fieldMask)
 }
+
+// Update a Foo. 'value' must at the least have
+// a primary key set. The 'fieldMask' field set indicates which fields
+// should be updated in the database.
+//
+// Returns the primary key of the updated row.
+func (conn *ConnPGClient) UpdateFoo(
+	ctx context.Context,
+	value *Foo,
+	fieldMask pggen.FieldSet,
+	opts ...pggen.UpdateOpt,
+) (ret int64, err error) {
+	return conn.impl.updateFoo(ctx, value, fieldMask)
+}
 func (p *pgClientImpl) updateFoo(
 	ctx context.Context,
 	value *Foo,
@@ -453,6 +522,30 @@ func (tx *TxPGClient) UpsertFoo(
 	return value.Id, nil
 }
 
+// Upsert a Foo value. If the given value conflicts with
+// an existing row in the database, use the provided value to update that row
+// rather than inserting it. Only the fields specified by 'fieldMask' are
+// actually updated. All other fields are left as-is.
+func (conn *ConnPGClient) UpsertFoo(
+	ctx context.Context,
+	value *Foo,
+	constraintNames []string,
+	fieldMask pggen.FieldSet,
+	opts ...pggen.UpsertOpt,
+) (ret int64, err error) {
+	var val []int64
+	val, err = conn.impl.bulkUpsertFoo(ctx, []Foo{*value}, constraintNames, fieldMask, opts...)
+	if err != nil {
+		return
+	}
+	if len(val) == 1 {
+		return val[0], nil
+	}
+
+	// only possible if no upsert fields were specified by the field mask
+	return value.Id, nil
+}
+
 // Upsert a set of Foo values. If any of the given values conflict with
 // existing rows in the database, use the provided values to update the rows which
 // exist in the database rather than inserting them. Only the fields specified by
@@ -479,6 +572,20 @@ func (tx *TxPGClient) BulkUpsertFoo(
 	opts ...pggen.UpsertOpt,
 ) (ret []int64, err error) {
 	return tx.impl.bulkUpsertFoo(ctx, values, constraintNames, fieldMask, opts...)
+}
+
+// Upsert a set of Foo values. If any of the given values conflict with
+// existing rows in the database, use the provided values to update the rows which
+// exist in the database rather than inserting them. Only the fields specified by
+// 'fieldMask' are actually updated. All other fields are left as-is.
+func (conn *ConnPGClient) BulkUpsertFoo(
+	ctx context.Context,
+	values []Foo,
+	constraintNames []string,
+	fieldMask pggen.FieldSet,
+	opts ...pggen.UpsertOpt,
+) (ret []int64, err error) {
+	return conn.impl.bulkUpsertFoo(ctx, values, constraintNames, fieldMask, opts...)
 }
 func (p *pgClientImpl) bulkUpsertFoo(
 	ctx context.Context,
@@ -596,6 +703,13 @@ func (tx *TxPGClient) DeleteFoo(
 ) error {
 	return tx.impl.bulkDeleteFoo(ctx, []int64{id}, opts...)
 }
+func (conn *ConnPGClient) DeleteFoo(
+	ctx context.Context,
+	id int64,
+	opts ...pggen.DeleteOpt,
+) error {
+	return conn.impl.bulkDeleteFoo(ctx, []int64{id}, opts...)
+}
 
 func (p *PGClient) BulkDeleteFoo(
 	ctx context.Context,
@@ -610,6 +724,13 @@ func (tx *TxPGClient) BulkDeleteFoo(
 	opts ...pggen.DeleteOpt,
 ) error {
 	return tx.impl.bulkDeleteFoo(ctx, ids, opts...)
+}
+func (conn *ConnPGClient) BulkDeleteFoo(
+	ctx context.Context,
+	ids []int64,
+	opts ...pggen.DeleteOpt,
+) error {
+	return conn.impl.bulkDeleteFoo(ctx, ids, opts...)
 }
 func (p *pgClientImpl) bulkDeleteFoo(
 	ctx context.Context,
@@ -669,6 +790,14 @@ func (tx *TxPGClient) FooFillIncludes(
 ) error {
 	return tx.impl.privateFooBulkFillIncludes(ctx, []*Foo{rec}, includes)
 }
+func (conn *ConnPGClient) FooFillIncludes(
+	ctx context.Context,
+	rec *Foo,
+	includes *include.Spec,
+	opts ...pggen.IncludeOpt,
+) error {
+	return conn.impl.privateFooBulkFillIncludes(ctx, []*Foo{rec}, includes)
+}
 
 func (p *PGClient) FooBulkFillIncludes(
 	ctx context.Context,
@@ -685,6 +814,14 @@ func (tx *TxPGClient) FooBulkFillIncludes(
 	opts ...pggen.IncludeOpt,
 ) error {
 	return tx.impl.privateFooBulkFillIncludes(ctx, recs, includes)
+}
+func (conn *ConnPGClient) FooBulkFillIncludes(
+	ctx context.Context,
+	recs []*Foo,
+	includes *include.Spec,
+	opts ...pggen.IncludeOpt,
+) error {
+	return conn.impl.privateFooBulkFillIncludes(ctx, recs, includes)
 }
 func (p *pgClientImpl) privateFooBulkFillIncludes(
 	ctx context.Context,
@@ -740,11 +877,21 @@ func (p *PGClient) MyGetFooValue(
 	)
 }
 
-func (p *TxPGClient) MyGetFooValue(
+func (tx *TxPGClient) MyGetFooValue(
 	ctx context.Context,
 	arg1 int64,
 ) (ret *string, err error) {
-	return p.impl.MyGetFooValue(
+	return tx.impl.MyGetFooValue(
+		ctx,
+		arg1,
+	)
+}
+
+func (conn *ConnPGClient) MyGetFooValue(
+	ctx context.Context,
+	arg1 int64,
+) (ret *string, err error) {
+	return conn.impl.MyGetFooValue(
 		ctx,
 		arg1,
 	)

--- a/examples/statement/models/models.gen.go
+++ b/examples/statement/models/models.gen.go
@@ -68,6 +68,15 @@ func (p *PGClient) BeginTx(ctx context.Context, opts *sql.TxOptions) (*TxPGClien
 	}, nil
 }
 
+func (p *PGClient) Conn(ctx context.Context) (*ConnPGClient, error) {
+	conn, err := p.topLevelDB.Conn(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ConnPGClient{impl: pgClientImpl{db: conn, client: p}}, nil
+}
+
 // A postgres client that operates within a transaction. Supports all the same
 // generated methods that PGClient does.
 type TxPGClient struct {
@@ -84,6 +93,18 @@ func (tx *TxPGClient) Rollback() error {
 
 func (tx *TxPGClient) Commit() error {
 	return tx.impl.db.(*sql.Tx).Commit()
+}
+
+type ConnPGClient struct {
+	impl pgClientImpl
+}
+
+func (conn *ConnPGClient) Close() error {
+	return conn.impl.db.(*sql.Conn).Close()
+}
+
+func (conn *ConnPGClient) Handle() pggen.DBHandle {
+	return conn.impl.db
 }
 
 // A database client that can wrap either a direct database connection or a transaction
@@ -106,6 +127,13 @@ func (tx *TxPGClient) GetUser(
 	opts ...pggen.GetOpt,
 ) (*User, error) {
 	return tx.impl.getUser(ctx, id)
+}
+func (conn *ConnPGClient) GetUser(
+	ctx context.Context,
+	id int64,
+	opts ...pggen.GetOpt,
+) (*User, error) {
+	return conn.impl.getUser(ctx, id)
 }
 func (p *pgClientImpl) getUser(
 	ctx context.Context,
@@ -135,6 +163,13 @@ func (tx *TxPGClient) ListUser(
 	opts ...pggen.ListOpt,
 ) (ret []User, err error) {
 	return tx.impl.listUser(ctx, ids, false /* isGet */)
+}
+func (conn *ConnPGClient) ListUser(
+	ctx context.Context,
+	ids []int64,
+	opts ...pggen.ListOpt,
+) (ret []User, err error) {
+	return conn.impl.listUser(ctx, ids, false /* isGet */)
 }
 func (p *pgClientImpl) listUser(
 	ctx context.Context,
@@ -219,6 +254,16 @@ func (tx *TxPGClient) InsertUser(
 
 // Insert a User into the database. Returns the primary
 // key of the inserted row.
+func (conn *ConnPGClient) InsertUser(
+	ctx context.Context,
+	value *User,
+	opts ...pggen.InsertOpt,
+) (ret int64, err error) {
+	return conn.impl.insertUser(ctx, value, opts...)
+}
+
+// Insert a User into the database. Returns the primary
+// key of the inserted row.
 func (p *pgClientImpl) insertUser(
 	ctx context.Context,
 	value *User,
@@ -257,6 +302,16 @@ func (tx *TxPGClient) BulkInsertUser(
 	opts ...pggen.InsertOpt,
 ) ([]int64, error) {
 	return tx.impl.bulkInsertUser(ctx, values, opts...)
+}
+
+// Insert a list of User. Returns a list of the primary keys of
+// the inserted rows.
+func (conn *ConnPGClient) BulkInsertUser(
+	ctx context.Context,
+	values []User,
+	opts ...pggen.InsertOpt,
+) ([]int64, error) {
+	return conn.impl.bulkInsertUser(ctx, values, opts...)
 }
 
 // Insert a list of User. Returns a list of the primary keys of
@@ -368,6 +423,20 @@ func (tx *TxPGClient) UpdateUser(
 ) (ret int64, err error) {
 	return tx.impl.updateUser(ctx, value, fieldMask)
 }
+
+// Update a User. 'value' must at the least have
+// a primary key set. The 'fieldMask' field set indicates which fields
+// should be updated in the database.
+//
+// Returns the primary key of the updated row.
+func (conn *ConnPGClient) UpdateUser(
+	ctx context.Context,
+	value *User,
+	fieldMask pggen.FieldSet,
+	opts ...pggen.UpdateOpt,
+) (ret int64, err error) {
+	return conn.impl.updateUser(ctx, value, fieldMask)
+}
 func (p *pgClientImpl) updateUser(
 	ctx context.Context,
 	value *User,
@@ -459,6 +528,30 @@ func (tx *TxPGClient) UpsertUser(
 	return value.Id, nil
 }
 
+// Upsert a User value. If the given value conflicts with
+// an existing row in the database, use the provided value to update that row
+// rather than inserting it. Only the fields specified by 'fieldMask' are
+// actually updated. All other fields are left as-is.
+func (conn *ConnPGClient) UpsertUser(
+	ctx context.Context,
+	value *User,
+	constraintNames []string,
+	fieldMask pggen.FieldSet,
+	opts ...pggen.UpsertOpt,
+) (ret int64, err error) {
+	var val []int64
+	val, err = conn.impl.bulkUpsertUser(ctx, []User{*value}, constraintNames, fieldMask, opts...)
+	if err != nil {
+		return
+	}
+	if len(val) == 1 {
+		return val[0], nil
+	}
+
+	// only possible if no upsert fields were specified by the field mask
+	return value.Id, nil
+}
+
 // Upsert a set of User values. If any of the given values conflict with
 // existing rows in the database, use the provided values to update the rows which
 // exist in the database rather than inserting them. Only the fields specified by
@@ -485,6 +578,20 @@ func (tx *TxPGClient) BulkUpsertUser(
 	opts ...pggen.UpsertOpt,
 ) (ret []int64, err error) {
 	return tx.impl.bulkUpsertUser(ctx, values, constraintNames, fieldMask, opts...)
+}
+
+// Upsert a set of User values. If any of the given values conflict with
+// existing rows in the database, use the provided values to update the rows which
+// exist in the database rather than inserting them. Only the fields specified by
+// 'fieldMask' are actually updated. All other fields are left as-is.
+func (conn *ConnPGClient) BulkUpsertUser(
+	ctx context.Context,
+	values []User,
+	constraintNames []string,
+	fieldMask pggen.FieldSet,
+	opts ...pggen.UpsertOpt,
+) (ret []int64, err error) {
+	return conn.impl.bulkUpsertUser(ctx, values, constraintNames, fieldMask, opts...)
 }
 func (p *pgClientImpl) bulkUpsertUser(
 	ctx context.Context,
@@ -609,6 +716,13 @@ func (tx *TxPGClient) DeleteUser(
 ) error {
 	return tx.impl.bulkDeleteUser(ctx, []int64{id}, opts...)
 }
+func (conn *ConnPGClient) DeleteUser(
+	ctx context.Context,
+	id int64,
+	opts ...pggen.DeleteOpt,
+) error {
+	return conn.impl.bulkDeleteUser(ctx, []int64{id}, opts...)
+}
 
 func (p *PGClient) BulkDeleteUser(
 	ctx context.Context,
@@ -623,6 +737,13 @@ func (tx *TxPGClient) BulkDeleteUser(
 	opts ...pggen.DeleteOpt,
 ) error {
 	return tx.impl.bulkDeleteUser(ctx, ids, opts...)
+}
+func (conn *ConnPGClient) BulkDeleteUser(
+	ctx context.Context,
+	ids []int64,
+	opts ...pggen.DeleteOpt,
+) error {
+	return conn.impl.bulkDeleteUser(ctx, ids, opts...)
 }
 func (p *pgClientImpl) bulkDeleteUser(
 	ctx context.Context,
@@ -682,6 +803,14 @@ func (tx *TxPGClient) UserFillIncludes(
 ) error {
 	return tx.impl.privateUserBulkFillIncludes(ctx, []*User{rec}, includes)
 }
+func (conn *ConnPGClient) UserFillIncludes(
+	ctx context.Context,
+	rec *User,
+	includes *include.Spec,
+	opts ...pggen.IncludeOpt,
+) error {
+	return conn.impl.privateUserBulkFillIncludes(ctx, []*User{rec}, includes)
+}
 
 func (p *PGClient) UserBulkFillIncludes(
 	ctx context.Context,
@@ -698,6 +827,14 @@ func (tx *TxPGClient) UserBulkFillIncludes(
 	opts ...pggen.IncludeOpt,
 ) error {
 	return tx.impl.privateUserBulkFillIncludes(ctx, recs, includes)
+}
+func (conn *ConnPGClient) UserBulkFillIncludes(
+	ctx context.Context,
+	recs []*User,
+	includes *include.Spec,
+	opts ...pggen.IncludeOpt,
+) error {
+	return conn.impl.privateUserBulkFillIncludes(ctx, recs, includes)
 }
 func (p *pgClientImpl) privateUserBulkFillIncludes(
 	ctx context.Context,
@@ -757,6 +894,15 @@ func (tx *TxPGClient) DeleteUsersByNickname(
 	arg1 string,
 ) (sql.Result, error) {
 	return tx.impl.DeleteUsersByNickname(
+		ctx,
+		arg1,
+	)
+}
+func (conn *ConnPGClient) DeleteUsersByNickname(
+	ctx context.Context,
+	arg1 string,
+) (sql.Result, error) {
+	return conn.impl.DeleteUsersByNickname(
 		ctx,
 		arg1,
 	)

--- a/examples/timestamps/models/models.gen.go
+++ b/examples/timestamps/models/models.gen.go
@@ -71,6 +71,15 @@ func (p *PGClient) BeginTx(ctx context.Context, opts *sql.TxOptions) (*TxPGClien
 	}, nil
 }
 
+func (p *PGClient) Conn(ctx context.Context) (*ConnPGClient, error) {
+	conn, err := p.topLevelDB.Conn(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ConnPGClient{impl: pgClientImpl{db: conn, client: p}}, nil
+}
+
 // A postgres client that operates within a transaction. Supports all the same
 // generated methods that PGClient does.
 type TxPGClient struct {
@@ -87,6 +96,18 @@ func (tx *TxPGClient) Rollback() error {
 
 func (tx *TxPGClient) Commit() error {
 	return tx.impl.db.(*sql.Tx).Commit()
+}
+
+type ConnPGClient struct {
+	impl pgClientImpl
+}
+
+func (conn *ConnPGClient) Close() error {
+	return conn.impl.db.(*sql.Conn).Close()
+}
+
+func (conn *ConnPGClient) Handle() pggen.DBHandle {
+	return conn.impl.db
 }
 
 // A database client that can wrap either a direct database connection or a transaction
@@ -109,6 +130,13 @@ func (tx *TxPGClient) GetUser(
 	opts ...pggen.GetOpt,
 ) (*User, error) {
 	return tx.impl.getUser(ctx, id)
+}
+func (conn *ConnPGClient) GetUser(
+	ctx context.Context,
+	id int64,
+	opts ...pggen.GetOpt,
+) (*User, error) {
+	return conn.impl.getUser(ctx, id)
 }
 func (p *pgClientImpl) getUser(
 	ctx context.Context,
@@ -138,6 +166,13 @@ func (tx *TxPGClient) ListUser(
 	opts ...pggen.ListOpt,
 ) (ret []User, err error) {
 	return tx.impl.listUser(ctx, ids, false /* isGet */)
+}
+func (conn *ConnPGClient) ListUser(
+	ctx context.Context,
+	ids []int64,
+	opts ...pggen.ListOpt,
+) (ret []User, err error) {
+	return conn.impl.listUser(ctx, ids, false /* isGet */)
 }
 func (p *pgClientImpl) listUser(
 	ctx context.Context,
@@ -222,6 +257,16 @@ func (tx *TxPGClient) InsertUser(
 
 // Insert a User into the database. Returns the primary
 // key of the inserted row.
+func (conn *ConnPGClient) InsertUser(
+	ctx context.Context,
+	value *User,
+	opts ...pggen.InsertOpt,
+) (ret int64, err error) {
+	return conn.impl.insertUser(ctx, value, opts...)
+}
+
+// Insert a User into the database. Returns the primary
+// key of the inserted row.
 func (p *pgClientImpl) insertUser(
 	ctx context.Context,
 	value *User,
@@ -260,6 +305,16 @@ func (tx *TxPGClient) BulkInsertUser(
 	opts ...pggen.InsertOpt,
 ) ([]int64, error) {
 	return tx.impl.bulkInsertUser(ctx, values, opts...)
+}
+
+// Insert a list of User. Returns a list of the primary keys of
+// the inserted rows.
+func (conn *ConnPGClient) BulkInsertUser(
+	ctx context.Context,
+	values []User,
+	opts ...pggen.InsertOpt,
+) ([]int64, error) {
+	return conn.impl.bulkInsertUser(ctx, values, opts...)
 }
 
 // Insert a list of User. Returns a list of the primary keys of
@@ -390,6 +445,20 @@ func (tx *TxPGClient) UpdateUser(
 ) (ret int64, err error) {
 	return tx.impl.updateUser(ctx, value, fieldMask)
 }
+
+// Update a User. 'value' must at the least have
+// a primary key set. The 'fieldMask' field set indicates which fields
+// should be updated in the database.
+//
+// Returns the primary key of the updated row.
+func (conn *ConnPGClient) UpdateUser(
+	ctx context.Context,
+	value *User,
+	fieldMask pggen.FieldSet,
+	opts ...pggen.UpdateOpt,
+) (ret int64, err error) {
+	return conn.impl.updateUser(ctx, value, fieldMask)
+}
 func (p *pgClientImpl) updateUser(
 	ctx context.Context,
 	value *User,
@@ -490,6 +559,30 @@ func (tx *TxPGClient) UpsertUser(
 	return value.Id, nil
 }
 
+// Upsert a User value. If the given value conflicts with
+// an existing row in the database, use the provided value to update that row
+// rather than inserting it. Only the fields specified by 'fieldMask' are
+// actually updated. All other fields are left as-is.
+func (conn *ConnPGClient) UpsertUser(
+	ctx context.Context,
+	value *User,
+	constraintNames []string,
+	fieldMask pggen.FieldSet,
+	opts ...pggen.UpsertOpt,
+) (ret int64, err error) {
+	var val []int64
+	val, err = conn.impl.bulkUpsertUser(ctx, []User{*value}, constraintNames, fieldMask, opts...)
+	if err != nil {
+		return
+	}
+	if len(val) == 1 {
+		return val[0], nil
+	}
+
+	// only possible if no upsert fields were specified by the field mask
+	return value.Id, nil
+}
+
 // Upsert a set of User values. If any of the given values conflict with
 // existing rows in the database, use the provided values to update the rows which
 // exist in the database rather than inserting them. Only the fields specified by
@@ -516,6 +609,20 @@ func (tx *TxPGClient) BulkUpsertUser(
 	opts ...pggen.UpsertOpt,
 ) (ret []int64, err error) {
 	return tx.impl.bulkUpsertUser(ctx, values, constraintNames, fieldMask, opts...)
+}
+
+// Upsert a set of User values. If any of the given values conflict with
+// existing rows in the database, use the provided values to update the rows which
+// exist in the database rather than inserting them. Only the fields specified by
+// 'fieldMask' are actually updated. All other fields are left as-is.
+func (conn *ConnPGClient) BulkUpsertUser(
+	ctx context.Context,
+	values []User,
+	constraintNames []string,
+	fieldMask pggen.FieldSet,
+	opts ...pggen.UpsertOpt,
+) (ret []int64, err error) {
+	return conn.impl.bulkUpsertUser(ctx, values, constraintNames, fieldMask, opts...)
 }
 func (p *pgClientImpl) bulkUpsertUser(
 	ctx context.Context,
@@ -665,6 +772,13 @@ func (tx *TxPGClient) DeleteUser(
 ) error {
 	return tx.impl.bulkDeleteUser(ctx, []int64{id}, opts...)
 }
+func (conn *ConnPGClient) DeleteUser(
+	ctx context.Context,
+	id int64,
+	opts ...pggen.DeleteOpt,
+) error {
+	return conn.impl.bulkDeleteUser(ctx, []int64{id}, opts...)
+}
 
 func (p *PGClient) BulkDeleteUser(
 	ctx context.Context,
@@ -679,6 +793,13 @@ func (tx *TxPGClient) BulkDeleteUser(
 	opts ...pggen.DeleteOpt,
 ) error {
 	return tx.impl.bulkDeleteUser(ctx, ids, opts...)
+}
+func (conn *ConnPGClient) BulkDeleteUser(
+	ctx context.Context,
+	ids []int64,
+	opts ...pggen.DeleteOpt,
+) error {
+	return conn.impl.bulkDeleteUser(ctx, ids, opts...)
 }
 func (p *pgClientImpl) bulkDeleteUser(
 	ctx context.Context,
@@ -752,6 +873,14 @@ func (tx *TxPGClient) UserFillIncludes(
 ) error {
 	return tx.impl.privateUserBulkFillIncludes(ctx, []*User{rec}, includes)
 }
+func (conn *ConnPGClient) UserFillIncludes(
+	ctx context.Context,
+	rec *User,
+	includes *include.Spec,
+	opts ...pggen.IncludeOpt,
+) error {
+	return conn.impl.privateUserBulkFillIncludes(ctx, []*User{rec}, includes)
+}
 
 func (p *PGClient) UserBulkFillIncludes(
 	ctx context.Context,
@@ -768,6 +897,14 @@ func (tx *TxPGClient) UserBulkFillIncludes(
 	opts ...pggen.IncludeOpt,
 ) error {
 	return tx.impl.privateUserBulkFillIncludes(ctx, recs, includes)
+}
+func (conn *ConnPGClient) UserBulkFillIncludes(
+	ctx context.Context,
+	recs []*User,
+	includes *include.Spec,
+	opts ...pggen.IncludeOpt,
+) error {
+	return conn.impl.privateUserBulkFillIncludes(ctx, recs, includes)
 }
 func (p *pgClientImpl) privateUserBulkFillIncludes(
 	ctx context.Context,
@@ -832,6 +969,16 @@ func (tx *TxPGClient) GetUserAnyway(
 		arg1,
 	)
 }
+
+func (conn *ConnPGClient) GetUserAnyway(
+	ctx context.Context,
+	arg1 int64,
+) (ret []User, err error) {
+	return conn.impl.GetUserAnyway(
+		ctx,
+		arg1,
+	)
+}
 func (p *pgClientImpl) GetUserAnyway(
 	ctx context.Context,
 	arg1 int64,
@@ -884,6 +1031,16 @@ func (tx *TxPGClient) GetUserAnywayQuery(
 	arg1 int64,
 ) (*sql.Rows, error) {
 	return tx.impl.GetUserAnywayQuery(
+		ctx,
+		arg1,
+	)
+}
+
+func (conn *ConnPGClient) GetUserAnywayQuery(
+	ctx context.Context,
+	arg1 int64,
+) (*sql.Rows, error) {
+	return conn.impl.GetUserAnywayQuery(
 		ctx,
 		arg1,
 	)

--- a/examples/upsert/models/models.gen.go
+++ b/examples/upsert/models/models.gen.go
@@ -68,6 +68,15 @@ func (p *PGClient) BeginTx(ctx context.Context, opts *sql.TxOptions) (*TxPGClien
 	}, nil
 }
 
+func (p *PGClient) Conn(ctx context.Context) (*ConnPGClient, error) {
+	conn, err := p.topLevelDB.Conn(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ConnPGClient{impl: pgClientImpl{db: conn, client: p}}, nil
+}
+
 // A postgres client that operates within a transaction. Supports all the same
 // generated methods that PGClient does.
 type TxPGClient struct {
@@ -84,6 +93,18 @@ func (tx *TxPGClient) Rollback() error {
 
 func (tx *TxPGClient) Commit() error {
 	return tx.impl.db.(*sql.Tx).Commit()
+}
+
+type ConnPGClient struct {
+	impl pgClientImpl
+}
+
+func (conn *ConnPGClient) Close() error {
+	return conn.impl.db.(*sql.Conn).Close()
+}
+
+func (conn *ConnPGClient) Handle() pggen.DBHandle {
+	return conn.impl.db
 }
 
 // A database client that can wrap either a direct database connection or a transaction
@@ -106,6 +127,13 @@ func (tx *TxPGClient) GetUser(
 	opts ...pggen.GetOpt,
 ) (*User, error) {
 	return tx.impl.getUser(ctx, id)
+}
+func (conn *ConnPGClient) GetUser(
+	ctx context.Context,
+	id int64,
+	opts ...pggen.GetOpt,
+) (*User, error) {
+	return conn.impl.getUser(ctx, id)
 }
 func (p *pgClientImpl) getUser(
 	ctx context.Context,
@@ -135,6 +163,13 @@ func (tx *TxPGClient) ListUser(
 	opts ...pggen.ListOpt,
 ) (ret []User, err error) {
 	return tx.impl.listUser(ctx, ids, false /* isGet */)
+}
+func (conn *ConnPGClient) ListUser(
+	ctx context.Context,
+	ids []int64,
+	opts ...pggen.ListOpt,
+) (ret []User, err error) {
+	return conn.impl.listUser(ctx, ids, false /* isGet */)
 }
 func (p *pgClientImpl) listUser(
 	ctx context.Context,
@@ -219,6 +254,16 @@ func (tx *TxPGClient) InsertUser(
 
 // Insert a User into the database. Returns the primary
 // key of the inserted row.
+func (conn *ConnPGClient) InsertUser(
+	ctx context.Context,
+	value *User,
+	opts ...pggen.InsertOpt,
+) (ret int64, err error) {
+	return conn.impl.insertUser(ctx, value, opts...)
+}
+
+// Insert a User into the database. Returns the primary
+// key of the inserted row.
 func (p *pgClientImpl) insertUser(
 	ctx context.Context,
 	value *User,
@@ -257,6 +302,16 @@ func (tx *TxPGClient) BulkInsertUser(
 	opts ...pggen.InsertOpt,
 ) ([]int64, error) {
 	return tx.impl.bulkInsertUser(ctx, values, opts...)
+}
+
+// Insert a list of User. Returns a list of the primary keys of
+// the inserted rows.
+func (conn *ConnPGClient) BulkInsertUser(
+	ctx context.Context,
+	values []User,
+	opts ...pggen.InsertOpt,
+) ([]int64, error) {
+	return conn.impl.bulkInsertUser(ctx, values, opts...)
 }
 
 // Insert a list of User. Returns a list of the primary keys of
@@ -373,6 +428,20 @@ func (tx *TxPGClient) UpdateUser(
 ) (ret int64, err error) {
 	return tx.impl.updateUser(ctx, value, fieldMask)
 }
+
+// Update a User. 'value' must at the least have
+// a primary key set. The 'fieldMask' field set indicates which fields
+// should be updated in the database.
+//
+// Returns the primary key of the updated row.
+func (conn *ConnPGClient) UpdateUser(
+	ctx context.Context,
+	value *User,
+	fieldMask pggen.FieldSet,
+	opts ...pggen.UpdateOpt,
+) (ret int64, err error) {
+	return conn.impl.updateUser(ctx, value, fieldMask)
+}
 func (p *pgClientImpl) updateUser(
 	ctx context.Context,
 	value *User,
@@ -467,6 +536,30 @@ func (tx *TxPGClient) UpsertUser(
 	return value.Id, nil
 }
 
+// Upsert a User value. If the given value conflicts with
+// an existing row in the database, use the provided value to update that row
+// rather than inserting it. Only the fields specified by 'fieldMask' are
+// actually updated. All other fields are left as-is.
+func (conn *ConnPGClient) UpsertUser(
+	ctx context.Context,
+	value *User,
+	constraintNames []string,
+	fieldMask pggen.FieldSet,
+	opts ...pggen.UpsertOpt,
+) (ret int64, err error) {
+	var val []int64
+	val, err = conn.impl.bulkUpsertUser(ctx, []User{*value}, constraintNames, fieldMask, opts...)
+	if err != nil {
+		return
+	}
+	if len(val) == 1 {
+		return val[0], nil
+	}
+
+	// only possible if no upsert fields were specified by the field mask
+	return value.Id, nil
+}
+
 // Upsert a set of User values. If any of the given values conflict with
 // existing rows in the database, use the provided values to update the rows which
 // exist in the database rather than inserting them. Only the fields specified by
@@ -493,6 +586,20 @@ func (tx *TxPGClient) BulkUpsertUser(
 	opts ...pggen.UpsertOpt,
 ) (ret []int64, err error) {
 	return tx.impl.bulkUpsertUser(ctx, values, constraintNames, fieldMask, opts...)
+}
+
+// Upsert a set of User values. If any of the given values conflict with
+// existing rows in the database, use the provided values to update the rows which
+// exist in the database rather than inserting them. Only the fields specified by
+// 'fieldMask' are actually updated. All other fields are left as-is.
+func (conn *ConnPGClient) BulkUpsertUser(
+	ctx context.Context,
+	values []User,
+	constraintNames []string,
+	fieldMask pggen.FieldSet,
+	opts ...pggen.UpsertOpt,
+) (ret []int64, err error) {
+	return conn.impl.bulkUpsertUser(ctx, values, constraintNames, fieldMask, opts...)
 }
 func (p *pgClientImpl) bulkUpsertUser(
 	ctx context.Context,
@@ -624,6 +731,13 @@ func (tx *TxPGClient) DeleteUser(
 ) error {
 	return tx.impl.bulkDeleteUser(ctx, []int64{id}, opts...)
 }
+func (conn *ConnPGClient) DeleteUser(
+	ctx context.Context,
+	id int64,
+	opts ...pggen.DeleteOpt,
+) error {
+	return conn.impl.bulkDeleteUser(ctx, []int64{id}, opts...)
+}
 
 func (p *PGClient) BulkDeleteUser(
 	ctx context.Context,
@@ -638,6 +752,13 @@ func (tx *TxPGClient) BulkDeleteUser(
 	opts ...pggen.DeleteOpt,
 ) error {
 	return tx.impl.bulkDeleteUser(ctx, ids, opts...)
+}
+func (conn *ConnPGClient) BulkDeleteUser(
+	ctx context.Context,
+	ids []int64,
+	opts ...pggen.DeleteOpt,
+) error {
+	return conn.impl.bulkDeleteUser(ctx, ids, opts...)
 }
 func (p *pgClientImpl) bulkDeleteUser(
 	ctx context.Context,
@@ -697,6 +818,14 @@ func (tx *TxPGClient) UserFillIncludes(
 ) error {
 	return tx.impl.privateUserBulkFillIncludes(ctx, []*User{rec}, includes)
 }
+func (conn *ConnPGClient) UserFillIncludes(
+	ctx context.Context,
+	rec *User,
+	includes *include.Spec,
+	opts ...pggen.IncludeOpt,
+) error {
+	return conn.impl.privateUserBulkFillIncludes(ctx, []*User{rec}, includes)
+}
 
 func (p *PGClient) UserBulkFillIncludes(
 	ctx context.Context,
@@ -713,6 +842,14 @@ func (tx *TxPGClient) UserBulkFillIncludes(
 	opts ...pggen.IncludeOpt,
 ) error {
 	return tx.impl.privateUserBulkFillIncludes(ctx, recs, includes)
+}
+func (conn *ConnPGClient) UserBulkFillIncludes(
+	ctx context.Context,
+	recs []*User,
+	includes *include.Spec,
+	opts ...pggen.IncludeOpt,
+) error {
+	return conn.impl.privateUserBulkFillIncludes(ctx, recs, includes)
 }
 func (p *pgClientImpl) privateUserBulkFillIncludes(
 	ctx context.Context,

--- a/gen/gen_query.go
+++ b/gen/gen_query.go
@@ -133,7 +133,7 @@ func (p *PGClient) {{ .ConfigData.Name }}(
 	)
 }
 {{ .Comment }}
-func (p *TxPGClient) {{ .ConfigData.Name }}(
+func (tx *TxPGClient) {{ .ConfigData.Name }}(
 	ctx context.Context,
 	{{- range .Args }}
 	{{ .GoName }} {{ .TypeInfo.Name }},
@@ -143,7 +143,25 @@ func (p *TxPGClient) {{ .ConfigData.Name }}(
 {{- else }}
 ) (ret *{{ .ReturnTypeName }}, err error) {
 {{- end }}
-	return p.impl.{{ .ConfigData.Name }}(
+	return tx.impl.{{ .ConfigData.Name }}(
+		ctx,
+		{{- range .Args }}
+		{{ .GoName }},
+		{{- end }}
+	)
+}
+{{ .Comment }}
+func (conn *ConnPGClient) {{ .ConfigData.Name }}(
+	ctx context.Context,
+	{{- range .Args }}
+	{{ .GoName }} {{ .TypeInfo.Name }},
+	{{- end }}
+{{- if (not .MultiReturn) }}
+) (ret {{ .ReturnTypeName }}, err error) {
+{{- else }}
+) (ret *{{ .ReturnTypeName }}, err error) {
+{{- end }}
+	return conn.impl.{{ .ConfigData.Name }}(
 		ctx,
 		{{- range .Args }}
 		{{ .GoName }},
@@ -250,6 +268,20 @@ func (tx *TxPGClient) {{ .ConfigData.Name }}(
 		{{- end }}
 	)
 }
+{{ .Comment }}
+func (conn *ConnPGClient) {{ .ConfigData.Name }}(
+	ctx context.Context,
+	{{- range .Args }}
+	{{ .GoName }} {{ .TypeInfo.Name }},
+	{{- end }}
+) (ret []{{ .ReturnTypeName }}, err error) {
+	return conn.impl.{{ .ConfigData.Name }}(
+		ctx,
+		{{- range .Args }}
+		{{ .GoName }},
+		{{- end }}
+	)
+}
 func (p *pgClientImpl) {{ .ConfigData.Name }}(
 	ctx context.Context,
 	{{- range .Args }}
@@ -329,6 +361,20 @@ func (tx *TxPGClient) {{ .ConfigData.Name }}Query(
 	{{- end }}
 ) (*sql.Rows, error) {
 	return tx.impl.{{ .ConfigData.Name }}Query(
+		ctx,
+		{{- range .Args}}
+		{{ .GoName }},
+		{{- end}}
+	)
+}
+{{ .Comment }}
+func (conn *ConnPGClient) {{ .ConfigData.Name }}Query(
+	ctx context.Context,
+	{{- range .Args }}
+	{{ .GoName }} {{ .TypeInfo.Name }},
+	{{- end }}
+) (*sql.Rows, error) {
+	return conn.impl.{{ .ConfigData.Name }}Query(
 		ctx,
 		{{- range .Args}}
 		{{ .GoName }},

--- a/gen/gen_stmt.go
+++ b/gen/gen_stmt.go
@@ -68,6 +68,19 @@ func (tx *TxPGClient) {{ .ConfigData.Name }}(
 		{{- end}}
 	)
 }
+func (conn *ConnPGClient) {{ .ConfigData.Name }}(
+	ctx context.Context,
+	{{- range .Args}}
+	{{ .GoName }} {{ .TypeInfo.Name }},
+	{{- end}}
+) (sql.Result, error) {
+	return conn.impl.{{ .ConfigData.Name }}(
+		ctx,
+		{{- range .Args}}
+		{{ .GoName }},
+		{{- end}}
+	)
+}
 func (p *pgClientImpl) {{ .ConfigData.Name }}(
 	ctx context.Context,
 	{{- range .Args}}


### PR DESCRIPTION
You can now use pggen to interact with postgres while locked
to a single connection. This is useful when working with session
level state like prepared statements or session level locks.

Closes #137