### PR TITLE
switch the pggen tool to jackc/pgx

### DIFF
--- a/gen/gen.go
+++ b/gen/gen.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 
 	"github.com/BurntSushi/toml"
-	_ "github.com/lib/pq"
+	_ "github.com/jackc/pgx/v4/stdlib"
 
 	"github.com/opendoor-labs/pggen/gen/internal/config"
 	"github.com/opendoor-labs/pggen/gen/internal/log"
@@ -83,7 +83,7 @@ func FromConfig(config Config) (*Generator, error) {
 			connStr = os.Getenv(connStr[1:])
 		}
 
-		db, err = sql.Open("postgres", connStr)
+		db, err = sql.Open("pgx", connStr)
 		if err != nil {
 			db = nil
 			continue

--- a/gen/internal/meta/meta_test.go
+++ b/gen/internal/meta/meta_test.go
@@ -58,28 +58,30 @@ func TestSplitType(t *testing.T) {
 	}
 
 	for i, v := range testVecs {
-		inputBytes := []byte(v.input)
+		t.Run(v.input, func(t *testing.T) {
+			t.Parallel()
 
-		var actual RegTypeArray
-		err := actual.Scan(inputBytes)
-		if err != nil &&
-			(!strings.Contains(err.Error(), v.expectedErr) ||
-				len(v.expectedErr) == 0) {
-			t.Errorf(
-				"\n(case %d) Error: %s\n       Expected Error: %s\n",
-				i,
-				err.Error(),
-				v.expectedErr,
-			)
-		}
+			var actual RegTypeArray
+			err := actual.Scan(v.input)
+			if err != nil &&
+				(!strings.Contains(err.Error(), v.expectedErr) ||
+					len(v.expectedErr) == 0) {
+				t.Errorf(
+					"\n(case %d) Error: %s\n       Expected Error: %s\n",
+					i,
+					err.Error(),
+					v.expectedErr,
+				)
+			}
 
-		if !reflect.DeepEqual(actual.pgTypes, v.expected) {
-			t.Errorf(
-				"\n(case %d) Actual: %#v\n       Expected: %#v\n",
-				i,
-				actual.pgTypes,
-				v.expected,
-			)
-		}
+			if !reflect.DeepEqual(actual.pgTypes, v.expected) {
+				t.Errorf(
+					"\n(case %d) Actual: %#v\n       Expected: %#v\n",
+					i,
+					actual.pgTypes,
+					v.expected,
+				)
+			}
+		})
 	}
 }


### PR DESCRIPTION
As part of the continued campaign to migrate from lib/pq
to jackc/pgx, this patch switches the database driver that
pggen itself uses when it is connecting to the database to
get at the meta tables. It seems that the two divers translate
one of the more esoteric system types differently, so some
code had to be adapted for that, but otherwise there is no
need to adapt.