### PR TITLE
use jackc/pgx as the primary driver for test

### DIFF
--- a/cmd/pggen/test/prepared_function_test.go
+++ b/cmd/pggen/test/prepared_function_test.go
@@ -7,8 +7,6 @@ import (
 	"regexp"
 	"testing"
 
-	_ "github.com/lib/pq"
-
 	"github.com/opendoor-labs/pggen/cmd/pggen/test/models"
 )
 

--- a/cmd/pggen/test/tables_test.go
+++ b/cmd/pggen/test/tables_test.go
@@ -2,7 +2,6 @@ package test
 
 import (
 	"database/sql"
-	"os"
 	"reflect"
 	"sort"
 	"testing"
@@ -1120,12 +1119,6 @@ func TestNotFoundList(t *testing.T) {
 }
 
 func TestDroppingColumnOnTheFly(t *testing.T) {
-	if os.Getenv("DB_DRIVER") == "pgx" {
-		// disable this test for jackc/pgx
-		// TODO: re-enable once https://github.com/jackc/pgx/issues/841 is resolved
-		return
-	}
-
 	// make sure we always start in a consistant state
 	_, err := pgClient.Handle().ExecContext(ctx, `
 		DROP TABLE drop_cols;

--- a/cmd/pggen/test/test.go
+++ b/cmd/pggen/test/test.go
@@ -34,7 +34,7 @@ func init() {
 
 	dbDriver, inEnv := os.LookupEnv("DB_DRIVER")
 	if !inEnv || dbDriver == "" {
-		dbDriver = "postgres" // default to using lib/pq
+		dbDriver = "pgx" // default to using jackc/pgx/v4/stdlib
 	}
 
 	db, err := sql.Open(dbDriver, dbURL)

--- a/examples/extending_models/models/models.gen.go
+++ b/examples/extending_models/models/models.gen.go
@@ -182,7 +182,7 @@ func (p *pgClientImpl) listDog(
 		return []Dog{}, nil
 	}
 
-	rows, err := p.db.QueryContext(
+	rows, err := p.queryContext(
 		ctx,
 		`SELECT * FROM dogs WHERE "id" = ANY($1)`,
 		pq.Array(ids),
@@ -357,7 +357,7 @@ func (p *pgClientImpl) bulkInsertDog(
 		defaultFields,
 	)
 
-	rows, err := p.db.QueryContext(ctx, bulkInsertQuery, args...)
+	rows, err := p.queryContext(ctx, bulkInsertQuery, args...)
 	if err != nil {
 		return nil, err
 	}
@@ -699,7 +699,7 @@ func (p *pgClientImpl) bulkUpsertDog(
 		}
 	}
 
-	rows, err := p.db.QueryContext(ctx, stmt.String(), args...)
+	rows, err := p.queryContext(ctx, stmt.String(), args...)
 	if err != nil {
 		return nil, err
 	}

--- a/examples/id_in_set/models/models.gen.go
+++ b/examples/id_in_set/models/models.gen.go
@@ -183,7 +183,7 @@ func (p *pgClientImpl) listFoo(
 		return []Foo{}, nil
 	}
 
-	rows, err := p.db.QueryContext(
+	rows, err := p.queryContext(
 		ctx,
 		`SELECT * FROM foos WHERE "id" = ANY($1)`,
 		pq.Array(ids),
@@ -352,7 +352,7 @@ func (p *pgClientImpl) bulkInsertFoo(
 		defaultFields,
 	)
 
-	rows, err := p.db.QueryContext(ctx, bulkInsertQuery, args...)
+	rows, err := p.queryContext(ctx, bulkInsertQuery, args...)
 	if err != nil {
 		return nil, err
 	}
@@ -670,7 +670,7 @@ func (p *pgClientImpl) bulkUpsertFoo(
 		}
 	}
 
-	rows, err := p.db.QueryContext(ctx, stmt.String(), args...)
+	rows, err := p.queryContext(ctx, stmt.String(), args...)
 	if err != nil {
 		return nil, err
 	}
@@ -971,7 +971,7 @@ func (p *pgClientImpl) GetFooValuesQuery(
 	ctx context.Context,
 	arg1 []int64,
 ) (*sql.Rows, error) {
-	return p.db.QueryContext(
+	return p.queryContext(
 		ctx,
 		`SELECT value FROM foos WHERE id = ANY($1)`,
 		pq.Array(arg1),

--- a/examples/include_specs/models/models.gen.go
+++ b/examples/include_specs/models/models.gen.go
@@ -185,7 +185,7 @@ func (p *pgClientImpl) listGrandparent(
 		return []Grandparent{}, nil
 	}
 
-	rows, err := p.db.QueryContext(
+	rows, err := p.queryContext(
 		ctx,
 		`SELECT * FROM grandparents WHERE "id" = ANY($1)`,
 		pq.Array(ids),
@@ -357,7 +357,7 @@ func (p *pgClientImpl) bulkInsertGrandparent(
 		defaultFields,
 	)
 
-	rows, err := p.db.QueryContext(ctx, bulkInsertQuery, args...)
+	rows, err := p.queryContext(ctx, bulkInsertQuery, args...)
 	if err != nil {
 		return nil, err
 	}
@@ -687,7 +687,7 @@ func (p *pgClientImpl) bulkUpsertGrandparent(
 		}
 	}
 
-	rows, err := p.db.QueryContext(ctx, stmt.String(), args...)
+	rows, err := p.queryContext(ctx, stmt.String(), args...)
 	if err != nil {
 		return nil, err
 	}
@@ -949,7 +949,7 @@ func (p *pgClientImpl) privateGrandparentFillParents(
 		childIDToRecord = map[int64]*Parent{}
 	}
 
-	rows, err := p.db.QueryContext(
+	rows, err := p.queryContext(
 		ctx,
 		`SELECT * FROM parents
 		 WHERE "grandparent_id" = ANY($1)
@@ -1047,7 +1047,7 @@ func (p *pgClientImpl) privateGrandparentFillParentFavoriteGrandkid(
 
 	// fetch any outstanding parent records
 	if len(ids) > 0 {
-		rows, err := p.db.QueryContext(
+		rows, err := p.queryContext(
 			ctx,
 			`SELECT * FROM children
 			WHERE id = ANY($1)`,
@@ -1145,7 +1145,7 @@ func (p *pgClientImpl) listParent(
 		return []Parent{}, nil
 	}
 
-	rows, err := p.db.QueryContext(
+	rows, err := p.queryContext(
 		ctx,
 		`SELECT * FROM parents WHERE "id" = ANY($1)`,
 		pq.Array(ids),
@@ -1317,7 +1317,7 @@ func (p *pgClientImpl) bulkInsertParent(
 		defaultFields,
 	)
 
-	rows, err := p.db.QueryContext(ctx, bulkInsertQuery, args...)
+	rows, err := p.queryContext(ctx, bulkInsertQuery, args...)
 	if err != nil {
 		return nil, err
 	}
@@ -1647,7 +1647,7 @@ func (p *pgClientImpl) bulkUpsertParent(
 		}
 	}
 
-	rows, err := p.db.QueryContext(ctx, stmt.String(), args...)
+	rows, err := p.queryContext(ctx, stmt.String(), args...)
 	if err != nil {
 		return nil, err
 	}
@@ -1909,7 +1909,7 @@ func (p *pgClientImpl) privateParentFillChildren(
 		childIDToRecord = map[int64]*Child{}
 	}
 
-	rows, err := p.db.QueryContext(
+	rows, err := p.queryContext(
 		ctx,
 		`SELECT * FROM children
 		 WHERE "parent_id" = ANY($1)
@@ -2001,7 +2001,7 @@ func (p *pgClientImpl) privateParentFillParentGrandparent(
 
 	// fetch any outstanding parent records
 	if len(ids) > 0 {
-		rows, err := p.db.QueryContext(
+		rows, err := p.queryContext(
 			ctx,
 			`SELECT * FROM grandparents
 			WHERE id = ANY($1)`,
@@ -2099,7 +2099,7 @@ func (p *pgClientImpl) listChild(
 		return []Child{}, nil
 	}
 
-	rows, err := p.db.QueryContext(
+	rows, err := p.queryContext(
 		ctx,
 		`SELECT * FROM children WHERE "id" = ANY($1)`,
 		pq.Array(ids),
@@ -2271,7 +2271,7 @@ func (p *pgClientImpl) bulkInsertChild(
 		defaultFields,
 	)
 
-	rows, err := p.db.QueryContext(ctx, bulkInsertQuery, args...)
+	rows, err := p.queryContext(ctx, bulkInsertQuery, args...)
 	if err != nil {
 		return nil, err
 	}
@@ -2601,7 +2601,7 @@ func (p *pgClientImpl) bulkUpsertChild(
 		}
 	}
 
-	rows, err := p.db.QueryContext(ctx, stmt.String(), args...)
+	rows, err := p.queryContext(ctx, stmt.String(), args...)
 	if err != nil {
 		return nil, err
 	}
@@ -2866,7 +2866,7 @@ func (p *pgClientImpl) privateChildFillDarlingGrandparents(
 		childIDToRecord = map[int64]*Grandparent{}
 	}
 
-	rows, err := p.db.QueryContext(
+	rows, err := p.queryContext(
 		ctx,
 		`SELECT * FROM grandparents
 		 WHERE "favorite_grandkid_id" = ANY($1)
@@ -2959,7 +2959,7 @@ func (p *pgClientImpl) privateChildFillParentParent(
 
 	// fetch any outstanding parent records
 	if len(ids) > 0 {
-		rows, err := p.db.QueryContext(
+		rows, err := p.queryContext(
 			ctx,
 			`SELECT * FROM parents
 			WHERE id = ANY($1)`,

--- a/examples/json_columns/models/models.gen.go
+++ b/examples/json_columns/models/models.gen.go
@@ -184,7 +184,7 @@ func (p *pgClientImpl) listUser(
 		return []User{}, nil
 	}
 
-	rows, err := p.db.QueryContext(
+	rows, err := p.queryContext(
 		ctx,
 		`SELECT * FROM users WHERE "id" = ANY($1)`,
 		pq.Array(ids),
@@ -362,7 +362,7 @@ func (p *pgClientImpl) bulkInsertUser(
 		defaultFields,
 	)
 
-	rows, err := p.db.QueryContext(ctx, bulkInsertQuery, args...)
+	rows, err := p.queryContext(ctx, bulkInsertQuery, args...)
 	if err != nil {
 		return nil, err
 	}
@@ -716,7 +716,7 @@ func (p *pgClientImpl) bulkUpsertUser(
 		}
 	}
 
-	rows, err := p.db.QueryContext(ctx, stmt.String(), args...)
+	rows, err := p.queryContext(ctx, stmt.String(), args...)
 	if err != nil {
 		return nil, err
 	}

--- a/examples/middleware/models/models.gen.go
+++ b/examples/middleware/models/models.gen.go
@@ -181,7 +181,7 @@ func (p *pgClientImpl) listFoo(
 		return []Foo{}, nil
 	}
 
-	rows, err := p.db.QueryContext(
+	rows, err := p.queryContext(
 		ctx,
 		`SELECT * FROM foos WHERE "id" = ANY($1)`,
 		pq.Array(ids),
@@ -350,7 +350,7 @@ func (p *pgClientImpl) bulkInsertFoo(
 		defaultFields,
 	)
 
-	rows, err := p.db.QueryContext(ctx, bulkInsertQuery, args...)
+	rows, err := p.queryContext(ctx, bulkInsertQuery, args...)
 	if err != nil {
 		return nil, err
 	}
@@ -668,7 +668,7 @@ func (p *pgClientImpl) bulkUpsertFoo(
 		}
 	}
 
-	rows, err := p.db.QueryContext(ctx, stmt.String(), args...)
+	rows, err := p.queryContext(ctx, stmt.String(), args...)
 	if err != nil {
 		return nil, err
 	}

--- a/examples/nullable_query_arguments/models/models.gen.go
+++ b/examples/nullable_query_arguments/models/models.gen.go
@@ -183,7 +183,7 @@ func (p *pgClientImpl) listUser(
 		return []User{}, nil
 	}
 
-	rows, err := p.db.QueryContext(
+	rows, err := p.queryContext(
 		ctx,
 		`SELECT * FROM users WHERE "id" = ANY($1)`,
 		pq.Array(ids),
@@ -355,7 +355,7 @@ func (p *pgClientImpl) bulkInsertUser(
 		defaultFields,
 	)
 
-	rows, err := p.db.QueryContext(ctx, bulkInsertQuery, args...)
+	rows, err := p.queryContext(ctx, bulkInsertQuery, args...)
 	if err != nil {
 		return nil, err
 	}
@@ -685,7 +685,7 @@ func (p *pgClientImpl) bulkUpsertUser(
 		}
 	}
 
-	rows, err := p.db.QueryContext(ctx, stmt.String(), args...)
+	rows, err := p.queryContext(ctx, stmt.String(), args...)
 	if err != nil {
 		return nil, err
 	}
@@ -1089,7 +1089,7 @@ func (p *pgClientImpl) GetUsersByNullableNicknameQuery(
 	ctx context.Context,
 	arg1 *string,
 ) (*sql.Rows, error) {
-	return p.db.QueryContext(
+	return p.queryContext(
 		ctx,
 		`SELECT * FROM users WHERE nickname = $1 OR (nickname IS NULL AND $1 IS NULL)`,
 		arg1,

--- a/examples/query/models/models.gen.go
+++ b/examples/query/models/models.gen.go
@@ -185,7 +185,7 @@ func (p *pgClientImpl) listUser(
 		return []User{}, nil
 	}
 
-	rows, err := p.db.QueryContext(
+	rows, err := p.queryContext(
 		ctx,
 		`SELECT * FROM users WHERE "id" = ANY($1)`,
 		pq.Array(ids),
@@ -357,7 +357,7 @@ func (p *pgClientImpl) bulkInsertUser(
 		defaultFields,
 	)
 
-	rows, err := p.db.QueryContext(ctx, bulkInsertQuery, args...)
+	rows, err := p.queryContext(ctx, bulkInsertQuery, args...)
 	if err != nil {
 		return nil, err
 	}
@@ -687,7 +687,7 @@ func (p *pgClientImpl) bulkUpsertUser(
 		}
 	}
 
-	rows, err := p.db.QueryContext(ctx, stmt.String(), args...)
+	rows, err := p.queryContext(ctx, stmt.String(), args...)
 	if err != nil {
 		return nil, err
 	}
@@ -989,7 +989,7 @@ func (p *pgClientImpl) GetUserNicknameAndEmailQuery(
 	ctx context.Context,
 	arg1 int64,
 ) (*sql.Rows, error) {
-	return p.db.QueryContext(
+	return p.queryContext(
 		ctx,
 		`SELECT nickname, email FROM users WHERE id = $1`,
 		arg1,
@@ -1107,7 +1107,7 @@ func (p *pgClientImpl) MyGetUserQuery(
 	ctx context.Context,
 	arg1 int64,
 ) (*sql.Rows, error) {
-	return p.db.QueryContext(
+	return p.queryContext(
 		ctx,
 		`SELECT * FROM users WHERE id = $1`,
 		arg1,

--- a/examples/query_argument_names/models/models.gen.go
+++ b/examples/query_argument_names/models/models.gen.go
@@ -183,7 +183,7 @@ func (p *pgClientImpl) listUser(
 		return []User{}, nil
 	}
 
-	rows, err := p.db.QueryContext(
+	rows, err := p.queryContext(
 		ctx,
 		`SELECT * FROM users WHERE "id" = ANY($1)`,
 		pq.Array(ids),
@@ -355,7 +355,7 @@ func (p *pgClientImpl) bulkInsertUser(
 		defaultFields,
 	)
 
-	rows, err := p.db.QueryContext(ctx, bulkInsertQuery, args...)
+	rows, err := p.queryContext(ctx, bulkInsertQuery, args...)
 	if err != nil {
 		return nil, err
 	}
@@ -685,7 +685,7 @@ func (p *pgClientImpl) bulkUpsertUser(
 		}
 	}
 
-	rows, err := p.db.QueryContext(ctx, stmt.String(), args...)
+	rows, err := p.queryContext(ctx, stmt.String(), args...)
 	if err != nil {
 		return nil, err
 	}
@@ -996,7 +996,7 @@ func (p *pgClientImpl) GetUserByEmailOrNicknameQuery(
 	email string,
 	nickname string,
 ) (*sql.Rows, error) {
-	return p.db.QueryContext(
+	return p.queryContext(
 		ctx,
 		`SELECT * FROM users WHERE email = $1 OR nickname = $2`,
 		email,

--- a/examples/single_results/models/models.gen.go
+++ b/examples/single_results/models/models.gen.go
@@ -183,7 +183,7 @@ func (p *pgClientImpl) listFoo(
 		return []Foo{}, nil
 	}
 
-	rows, err := p.db.QueryContext(
+	rows, err := p.queryContext(
 		ctx,
 		`SELECT * FROM foos WHERE "id" = ANY($1)`,
 		pq.Array(ids),
@@ -352,7 +352,7 @@ func (p *pgClientImpl) bulkInsertFoo(
 		defaultFields,
 	)
 
-	rows, err := p.db.QueryContext(ctx, bulkInsertQuery, args...)
+	rows, err := p.queryContext(ctx, bulkInsertQuery, args...)
 	if err != nil {
 		return nil, err
 	}
@@ -670,7 +670,7 @@ func (p *pgClientImpl) bulkUpsertFoo(
 		}
 	}
 
-	rows, err := p.db.QueryContext(ctx, stmt.String(), args...)
+	rows, err := p.queryContext(ctx, stmt.String(), args...)
 	if err != nil {
 		return nil, err
 	}
@@ -906,7 +906,7 @@ func (p *pgClientImpl) MyGetFooValue(
 	// impl remains consistant. We don't need to split out a seperate Query
 	// method though.
 	var rows *sql.Rows
-	rows, err = p.db.QueryContext(
+	rows, err = p.queryContext(
 		ctx,
 		`SELECT value FROM foos WHERE id = $1`,
 		arg1,

--- a/examples/statement/models/models.gen.go
+++ b/examples/statement/models/models.gen.go
@@ -181,7 +181,7 @@ func (p *pgClientImpl) listUser(
 		return []User{}, nil
 	}
 
-	rows, err := p.db.QueryContext(
+	rows, err := p.queryContext(
 		ctx,
 		`SELECT * FROM users WHERE "id" = ANY($1)`,
 		pq.Array(ids),
@@ -353,7 +353,7 @@ func (p *pgClientImpl) bulkInsertUser(
 		defaultFields,
 	)
 
-	rows, err := p.db.QueryContext(ctx, bulkInsertQuery, args...)
+	rows, err := p.queryContext(ctx, bulkInsertQuery, args...)
 	if err != nil {
 		return nil, err
 	}
@@ -683,7 +683,7 @@ func (p *pgClientImpl) bulkUpsertUser(
 		}
 	}
 
-	rows, err := p.db.QueryContext(ctx, stmt.String(), args...)
+	rows, err := p.queryContext(ctx, stmt.String(), args...)
 	if err != nil {
 		return nil, err
 	}

--- a/examples/timestamps/models/models.gen.go
+++ b/examples/timestamps/models/models.gen.go
@@ -184,7 +184,7 @@ func (p *pgClientImpl) listUser(
 		return []User{}, nil
 	}
 
-	rows, err := p.db.QueryContext(
+	rows, err := p.queryContext(
 		ctx,
 		`SELECT * FROM users WHERE "id" = ANY($1) AND "deleted_at" IS NULL `,
 		pq.Array(ids),
@@ -371,7 +371,7 @@ func (p *pgClientImpl) bulkInsertUser(
 		defaultFields,
 	)
 
-	rows, err := p.db.QueryContext(ctx, bulkInsertQuery, args...)
+	rows, err := p.queryContext(ctx, bulkInsertQuery, args...)
 	if err != nil {
 		return nil, err
 	}
@@ -739,7 +739,7 @@ func (p *pgClientImpl) bulkUpsertUser(
 		}
 	}
 
-	rows, err := p.db.QueryContext(ctx, stmt.String(), args...)
+	rows, err := p.queryContext(ctx, stmt.String(), args...)
 	if err != nil {
 		return nil, err
 	}
@@ -1049,7 +1049,7 @@ func (p *pgClientImpl) GetUserAnywayQuery(
 	ctx context.Context,
 	arg1 int64,
 ) (*sql.Rows, error) {
-	return p.db.QueryContext(
+	return p.queryContext(
 		ctx,
 		`SELECT * FROM users WHERE id = $1`,
 		arg1,

--- a/examples/upsert/models/models.gen.go
+++ b/examples/upsert/models/models.gen.go
@@ -181,7 +181,7 @@ func (p *pgClientImpl) listUser(
 		return []User{}, nil
 	}
 
-	rows, err := p.db.QueryContext(
+	rows, err := p.queryContext(
 		ctx,
 		`SELECT * FROM users WHERE "id" = ANY($1)`,
 		pq.Array(ids),
@@ -356,7 +356,7 @@ func (p *pgClientImpl) bulkInsertUser(
 		defaultFields,
 	)
 
-	rows, err := p.db.QueryContext(ctx, bulkInsertQuery, args...)
+	rows, err := p.queryContext(ctx, bulkInsertQuery, args...)
 	if err != nil {
 		return nil, err
 	}
@@ -698,7 +698,7 @@ func (p *pgClientImpl) bulkUpsertUser(
 		}
 	}
 
-	rows, err := p.db.QueryContext(ctx, stmt.String(), args...)
+	rows, err := p.queryContext(ctx, stmt.String(), args...)
 	if err != nil {
 		return nil, err
 	}

--- a/gen/gen_prelude.go
+++ b/gen/gen_prelude.go
@@ -39,6 +39,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"github.com/jackc/pgconn"
 	uuid "github.com/satori/go.uuid"
 
 	"github.com/opendoor-labs/pggen"
@@ -227,6 +228,30 @@ func (p *PGClient) fillColPosTab(
 	return nil
 }
 
+func (p *pgClientImpl) queryContext(ctx context.Context, query string, args ...interface{}) (*sql.Rows, error) {
+	rows, err := p.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		if isInvalidCachedPlanError(err) {
+			// pgx will have flushed its cache as it bubbled this error up, so
+			// let's retry the query once
+			return p.db.QueryContext(ctx, query, args...)
+		}
+
+		return rows, err
+	}
+	return rows, err
+}
+
+func isInvalidCachedPlanError(err error) bool {
+	pgxErr, isPgxErr := err.(*pgconn.PgError)
+	if !isPgxErr {
+		return false
+	}
+
+	return pgxErr.Code == "0A000" &&
+		   pgxErr.Severity == "ERROR" &&
+		   pgxErr.Message == "cached plan must not change result type"
+}
 
 func convertNullString(s sql.NullString) *string {
 	if s.Valid {
@@ -242,7 +267,7 @@ func convertNullBool(b sql.NullBool) *bool {
 	return nil
 }
 
-// a type that will accept SQL result and just throw it away
+// a type that will accept an SQL result and just throw it away
 type pggenSinkScanner struct {}
 func (s *pggenSinkScanner) Scan(value interface{}) error {
 	return nil

--- a/gen/gen_query.go
+++ b/gen/gen_query.go
@@ -205,7 +205,7 @@ func (p *pgClientImpl) {{ .ConfigData.Name }}(
 	// method though.
 	var rows *sql.Rows
 	{{- /* We can't call out to *Query method because this is in the SingleResult block. */}}
-	rows, err = p.db.QueryContext(
+	rows, err = p.queryContext(
 		ctx,
 		` + "`" +
 	`{{ .ConfigData.Body }}` +
@@ -440,7 +440,7 @@ func (p *pgClientImpl) {{ .ConfigData.Name }}Query(
 	{{- end }}
 	{{- end }}
 ) (*sql.Rows, error) {
-	return p.db.QueryContext(
+	return p.queryContext(
 		ctx,
 		` + "`" +
 	`{{ .ConfigData.Body }}` +

--- a/gen/gen_table.go
+++ b/gen/gen_table.go
@@ -152,7 +152,7 @@ func (p *pgClientImpl) list{{ .GoName }}(
 		return []{{ .GoName }}{}, nil
 	}
 
-	rows, err := p.db.QueryContext(
+	rows, err := p.queryContext(
 		ctx,
 		` + "`" + `SELECT * FROM {{ .PgName }} WHERE "{{ .PkeyCol.PgName }}" = ANY($1)
 		{{- if .Meta.HasDeletedAtField }} AND "{{ .Meta.PgDeletedAtField }}" IS NULL {{ end }}` + "`" + `,
@@ -371,7 +371,7 @@ func (p *pgClientImpl) bulkInsert{{ .GoName }}(
 		defaultFields,
 	)
 
-	rows, err := p.db.QueryContext(ctx, bulkInsertQuery, args...)
+	rows, err := p.queryContext(ctx, bulkInsertQuery, args...)
 	if err != nil {
 		return nil, err
 	}
@@ -762,7 +762,7 @@ func (p *pgClientImpl) bulkUpsert{{ .GoName }}(
 		{{- end }}
 	}
 
-	rows, err := p.db.QueryContext(ctx, stmt.String(), args...)
+	rows, err := p.queryContext(ctx, stmt.String(), args...)
 	if err != nil {
 		return nil, err
 	}
@@ -1073,7 +1073,7 @@ func (p *pgClientImpl) private{{ $.GoName }}Fill{{ .GoPointsFromFieldName }}(
 		childIDToRecord = map[{{ .PointsFrom.Info.PkeyCol.TypeInfo.Name }}]*{{ .PointsFrom.Info.GoName }}{}
 	}
 
-	rows, err := p.db.QueryContext(
+	rows, err := p.queryContext(
 		ctx,
 		` + "`" +
 	`SELECT * FROM {{ .PointsFrom.Info.PgName }}
@@ -1200,7 +1200,7 @@ func (p *pgClientImpl) private{{ $.GoName }}FillParent{{ .GoPointsToFieldName }}
 
 	// fetch any outstanding parent records
 	if len(ids) > 0 {
-		rows, err := p.db.QueryContext(
+		rows, err := p.queryContext(
 			ctx,
 		` + "`" +
 	`SELECT * FROM {{ .PointsTo.Info.PgName }}

--- a/go.mod
+++ b/go.mod
@@ -5,12 +5,17 @@ go 1.13
 require (
 	github.com/BurntSushi/toml v0.3.1
 	github.com/google/uuid v1.1.1
-	github.com/jackc/pgx/v4 v4.9.0
+	github.com/jackc/pgconn v1.8.0
+	github.com/jackc/pgproto3/v2 v2.0.7 // indirect
+	github.com/jackc/pgx/v4 v4.10.1
 	github.com/jinzhu/gorm v1.9.12
 	github.com/jinzhu/inflection v1.0.0
 	github.com/kr/pretty v0.2.0 // indirect
 	github.com/lib/pq v1.3.0
 	github.com/satori/go.uuid v1.2.0
 	github.com/willf/bitset v1.1.10
+	golang.org/x/crypto v0.0.0-20210317152858-513c2a44f670 // indirect
+	golang.org/x/text v0.3.5 // indirect
+	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -36,6 +36,8 @@ github.com/jackc/pgconn v1.5.0/go.mod h1:QeD3lBfpTFe8WUnPZWN5KY/mB8FGMIYRdd8P8Jr
 github.com/jackc/pgconn v1.5.1-0.20200601181101-fa742c524853/go.mod h1:QeD3lBfpTFe8WUnPZWN5KY/mB8FGMIYRdd8P8Jr0fAI=
 github.com/jackc/pgconn v1.7.0 h1:pwjzcYyfmz/HQOQlENvG1OcDqauTGaqlVahq934F0/U=
 github.com/jackc/pgconn v1.7.0/go.mod h1:sF/lPpNEMEOp+IYhyQGdAvrG20gWf6A1tKlr0v7JMeA=
+github.com/jackc/pgconn v1.8.0 h1:FmjZ0rOyXTr1wfWs45i4a9vjnjWUAGpMuQLD9OSs+lw=
+github.com/jackc/pgconn v1.8.0/go.mod h1:1C2Pb36bGIP9QHGBYCjnyhqu7Rv3sGshaQUvmfGIB/o=
 github.com/jackc/pgio v1.0.0 h1:g12B9UwVnzGhueNavwioyEEpAmqMe1E/BN9ES+8ovkE=
 github.com/jackc/pgio v1.0.0/go.mod h1:oP+2QK2wFfUWgr+gxjoBH9KGBb31Eio69xUb0w5bYf8=
 github.com/jackc/pgmock v0.0.0-20190831213851-13a1b77aafa2 h1:JVX6jT/XfzNqIjye4717ITLaNwV9mWbJx0dLCpcRzdA=
@@ -51,6 +53,10 @@ github.com/jackc/pgproto3/v2 v2.0.0-rc3.0.20190831210041-4c03ce451f29/go.mod h1:
 github.com/jackc/pgproto3/v2 v2.0.1/go.mod h1:WfJCnwN3HIg9Ish/j3sgWXnAfK8A9Y0bwXYU5xKaEdA=
 github.com/jackc/pgproto3/v2 v2.0.5 h1:NUbEWPmCQZbMmYlTjVoNPhc0CfnYyz2bfUAh6A5ZVJM=
 github.com/jackc/pgproto3/v2 v2.0.5/go.mod h1:WfJCnwN3HIg9Ish/j3sgWXnAfK8A9Y0bwXYU5xKaEdA=
+github.com/jackc/pgproto3/v2 v2.0.6 h1:b1105ZGEMFe7aCvrT1Cca3VoVb4ZFMaFJLJcg/3zD+8=
+github.com/jackc/pgproto3/v2 v2.0.6/go.mod h1:WfJCnwN3HIg9Ish/j3sgWXnAfK8A9Y0bwXYU5xKaEdA=
+github.com/jackc/pgproto3/v2 v2.0.7 h1:6Pwi1b3QdY65cuv6SyVO0FgPd5J3Bl7wf/nQQjinHMA=
+github.com/jackc/pgproto3/v2 v2.0.7/go.mod h1:WfJCnwN3HIg9Ish/j3sgWXnAfK8A9Y0bwXYU5xKaEdA=
 github.com/jackc/pgservicefile v0.0.0-20200307190119-3430c5407db8/go.mod h1:vsD4gTJCa9TptPL8sPkXrLZ+hDuNrZCnj29CQpr4X1E=
 github.com/jackc/pgservicefile v0.0.0-20200714003250-2b9c44734f2b h1:C8S2+VttkHFdOOCXJe+YGfa4vHYwlt4Zx+IVXQ97jYg=
 github.com/jackc/pgservicefile v0.0.0-20200714003250-2b9c44734f2b/go.mod h1:vsD4gTJCa9TptPL8sPkXrLZ+hDuNrZCnj29CQpr4X1E=
@@ -62,6 +68,8 @@ github.com/jackc/pgtype v1.3.1-0.20200510190516-8cd94a14c75a/go.mod h1:vaogEUkAL
 github.com/jackc/pgtype v1.3.1-0.20200606141011-f6355165a91c/go.mod h1:cvk9Bgu/VzJ9/lxTO5R5sf80p0DiucVtN7ZxvaC4GmQ=
 github.com/jackc/pgtype v1.5.0 h1:jzBqRk2HFG2CV4AIwgCI2PwTgm6UUoCAK2ofHHRirtc=
 github.com/jackc/pgtype v1.5.0/go.mod h1:JCULISAZBFGrHaOXIIFiyfzW5VY0GRitRr8NeJsrdig=
+github.com/jackc/pgtype v1.6.2 h1:b3pDeuhbbzBYcg5kwNmNDun4pFUD/0AAr1kLXZLeNt8=
+github.com/jackc/pgtype v1.6.2/go.mod h1:JCULISAZBFGrHaOXIIFiyfzW5VY0GRitRr8NeJsrdig=
 github.com/jackc/pgx/v4 v4.0.0-20190420224344-cc3461e65d96/go.mod h1:mdxmSJJuR08CZQyj1PVQBHy9XOp5p8/SHH6a0psbY9Y=
 github.com/jackc/pgx/v4 v4.0.0-20190421002000-1b8f0016e912/go.mod h1:no/Y67Jkk/9WuGR0JG/JseM9irFbnEPbuWV2EELPNuM=
 github.com/jackc/pgx/v4 v4.0.0-pre1.0.20190824185557-6972a5742186/go.mod h1:X+GQnOEnf1dqHGpw7JmHqHc1NxDoalibchSk9/RWuDc=
@@ -70,11 +78,14 @@ github.com/jackc/pgx/v4 v4.6.1-0.20200510190926-94ba730bb1e9/go.mod h1:t3/cdRQl6
 github.com/jackc/pgx/v4 v4.6.1-0.20200606145419-4e5062306904/go.mod h1:ZDaNWkt9sW1JMiNn0kdYBaLelIhw7Pg4qd+Vk6tw7Hg=
 github.com/jackc/pgx/v4 v4.9.0 h1:6STjDqppM2ROy5p1wNDcsC7zJTjSHeuCsguZmXyzx7c=
 github.com/jackc/pgx/v4 v4.9.0/go.mod h1:MNGWmViCgqbZck9ujOOBN63gK9XVGILXWCvKLGKmnms=
+github.com/jackc/pgx/v4 v4.10.1 h1:/6Q3ye4myIj6AaplUm+eRcz4OhK9HAvFf4ePsG40LJY=
+github.com/jackc/pgx/v4 v4.10.1/go.mod h1:QlrWebbs3kqEZPHCTGyxecvzG6tvIsYu+A5b1raylkA=
 github.com/jackc/puddle v0.0.0-20190413234325-e4ced69a3a2b/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jackc/puddle v0.0.0-20190608224051-11cab39313c9/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jackc/puddle v1.1.0/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jackc/puddle v1.1.1/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jackc/puddle v1.1.2/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
+github.com/jackc/puddle v1.1.3/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jinzhu/gorm v1.9.12 h1:Drgk1clyWT9t9ERbzHza6Mj/8FY/CqMyVzOiHviMo6Q=
 github.com/jinzhu/gorm v1.9.12/go.mod h1:vhTjlKSJUTWNtcbQtrMBFCxy7eXTzeCAzfL5fBZT/Qs=
 github.com/jinzhu/inflection v1.0.0 h1:K317FqzuhWc8YvSVlFMCCUb36O/S9MCKRDI7QkRKD/E=
@@ -151,6 +162,8 @@ golang.org/x/crypto v0.0.0-20191205180655-e7c4368fe9dd/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20200323165209-0ec3e9974c59/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9 h1:psW17arqaxU48Z5kZ0CQnkZWQJsqcURM6tKiBApRjXI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/crypto v0.0.0-20210317152858-513c2a44f670 h1:gzMM0EjIYiRmJI3+jBdFuoynZlpxa2JQZsolKu09BXo=
+golang.org/x/crypto v0.0.0-20210317152858-513c2a44f670/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
 golang.org/x/lint v0.0.0-20190930215403-16217165b5de/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/mod v0.0.0-20190513183733-4bf6d317e70e/go.mod h1:mXi4GBBbnImb6dmsKGUJ2LatrhH/nqhxcFungHvyanc=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -158,6 +171,7 @@ golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190813141303-74dc4d7220e7/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -169,10 +183,14 @@ golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190826190057-c7b8b68b1456/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/text v0.3.3 h1:cokOdA+Jmi5PJGXLlLllQSgYigAEfHXJAERHVMaCc2k=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+golang.org/x/text v0.3.5 h1:i6eZZ+zk0SOf0xgBpEpPD18qWcJda6q1sxt3S0kzyUQ=
+golang.org/x/text v0.3.5/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190311212946-11955173bddd/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/tools v0.0.0-20190425163242-31fd60d6bfdc/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
@@ -185,6 +203,8 @@ golang.org/x/xerrors v0.0.0-20190513163551-3ee3066db522/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
+golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/appengine v1.4.0 h1:/wp5JvzpHIxhs/dumFmF7BXTf3Z+dd4uXta4kVyO508=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/tools/test.bash
+++ b/tools/test.bash
@@ -37,10 +37,10 @@ if [[ -n "${LINT+x}" ]] ; then
 elif go version | grep '1.13' 2>&1 >/dev/null ; then
     # for some reason the race detector acts weird with go 1.13
     go test -p 1 ./...
-    DB_DRIVER=pgx go test -p 1 ./cmd/pggen/test # re-run using jackc/pgx as the driver
+    DB_DRIVER=postgres go test -p 1 ./cmd/pggen/test # re-run using lib/pq as the driver
 else
     # We have to serialize the tests because the example tests will re-write the database
     # schema dynamically. We could fix this by creating a dedicated database for the example tests.
     go test -race -p 1 ./...
-    DB_DRIVER=pgx go test -race -p 1 ./cmd/pggen/test # re-run using jackc/pgx as the driver
+    DB_DRIVER=postgres go test -race -p 1 ./cmd/pggen/test # re-run using lib/pq as the driver
 fi


### PR DESCRIPTION
This patch re-enables the dynamic schema change test for
jackc/pgx, teaches pggen to automatically retry queries
when there is an invalid plan error due to a dynamic schema
change, and makes jackc/pgx the default driver to test against
(though we still test against lib/pq in CI). We will probably
drop official support for lib/pq at some point soon, though I
plan to keep testing against it if the maintenance burden is
not too high.