### PR TITLE
fully switch over to jackc pgx

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -96,17 +96,14 @@ so that we can share the source between the host and the container during local 
 
 ## Testing Non-Default Drivers
 
-`pggen` supports using both `github.com/lib/pq` and `github.com/jackc/pgx/stdlib` as
-database drivers. For the moment `lib/pq` is recommended because `jackc/pgx` contains
-a [nasty bug](https://github.com/jackc/pgx/issues/841) that prevents our test suite
-from passing fully. Going forward we do want to switch to recommending `jackc/pgx`,
-as it is more actively maintained than `lib/pq`.
+`pggen` supports using both `github.com/lib/pq` and `github.com/jackc/pgx/v4/stdlib` as
+database drivers. `jackc/pgx` is recommended because `lib/pq` is unmaintained.
 
-The example tests all use the recommended driver (`lib/pq`) for testing to keep the example code
+The example tests all use the recommended driver (`jackc/pgx`) for testing to keep the example code
 simple. The main test suite `cmd/pggen/test` is parameterized over the driver though. It
 allows you to you set the driver name via the `DB_DRIVER` environment variable. You can
 either set this variable to `postgres` (to use `lib/pq`) or `pgx` (to use
-`github.com/jackc/pgx/stdlib`).
+`github.com/jackc/pgx/v4/stdlib`).
 
 The `tools/test.bash` script runs the test suite both ways.
 

--- a/cmd/pggen/main.go
+++ b/cmd/pggen/main.go
@@ -6,8 +6,6 @@ import (
 	"os"
 	"strings"
 
-	_ "github.com/lib/pq"
-
 	"github.com/opendoor-labs/pggen/gen"
 )
 

--- a/cmd/pggen/test/test.go
+++ b/cmd/pggen/test/test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	_ "github.com/jackc/pgx/v4/stdlib" // load driver
+	_ "github.com/lib/pq"              // load driver (we still test against lib/pq)
 	"log"
 	"os"
 	"os/exec"

--- a/examples/extending_models/models/models.gen.go
+++ b/examples/extending_models/models/models.gen.go
@@ -7,7 +7,7 @@ import (
 	"database/sql"
 	"database/sql/driver"
 	"fmt"
-	"github.com/lib/pq"
+	"github.com/ethanpailes/pgtypes"
 	"github.com/opendoor-labs/pggen"
 	"github.com/opendoor-labs/pggen/include"
 	"github.com/opendoor-labs/pggen/unstable"
@@ -185,7 +185,7 @@ func (p *pgClientImpl) listDog(
 	rows, err := p.queryContext(
 		ctx,
 		`SELECT * FROM dogs WHERE "id" = ANY($1)`,
-		pq.Array(ids),
+		pgtypes.Array(ids),
 	)
 	if err != nil {
 		return nil, err
@@ -777,7 +777,7 @@ func (p *pgClientImpl) bulkDeleteDog(
 	res, err := p.db.ExecContext(
 		ctx,
 		`DELETE FROM dogs WHERE "id" = ANY($1)`,
-		pq.Array(ids),
+		pgtypes.Array(ids),
 	)
 	if err != nil {
 		return err

--- a/examples/id_in_set/models/models.gen.go
+++ b/examples/id_in_set/models/models.gen.go
@@ -6,7 +6,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"github.com/lib/pq"
+	"github.com/ethanpailes/pgtypes"
 	"github.com/opendoor-labs/pggen"
 	"github.com/opendoor-labs/pggen/include"
 	"github.com/opendoor-labs/pggen/unstable"
@@ -186,7 +186,7 @@ func (p *pgClientImpl) listFoo(
 	rows, err := p.queryContext(
 		ctx,
 		`SELECT * FROM foos WHERE "id" = ANY($1)`,
-		pq.Array(ids),
+		pgtypes.Array(ids),
 	)
 	if err != nil {
 		return nil, err
@@ -748,7 +748,7 @@ func (p *pgClientImpl) bulkDeleteFoo(
 	res, err := p.db.ExecContext(
 		ctx,
 		`DELETE FROM foos WHERE "id" = ANY($1)`,
-		pq.Array(ids),
+		pgtypes.Array(ids),
 	)
 	if err != nil {
 		return err
@@ -974,7 +974,7 @@ func (p *pgClientImpl) GetFooValuesQuery(
 	return p.queryContext(
 		ctx,
 		`SELECT value FROM foos WHERE id = ANY($1)`,
-		pq.Array(arg1),
+		pgtypes.Array(arg1),
 	)
 }
 

--- a/examples/include_specs/models/models.gen.go
+++ b/examples/include_specs/models/models.gen.go
@@ -6,7 +6,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"github.com/lib/pq"
+	"github.com/ethanpailes/pgtypes"
 	"github.com/opendoor-labs/pggen"
 	"github.com/opendoor-labs/pggen/include"
 	"github.com/opendoor-labs/pggen/unstable"
@@ -188,7 +188,7 @@ func (p *pgClientImpl) listGrandparent(
 	rows, err := p.queryContext(
 		ctx,
 		`SELECT * FROM grandparents WHERE "id" = ANY($1)`,
-		pq.Array(ids),
+		pgtypes.Array(ids),
 	)
 	if err != nil {
 		return nil, err
@@ -765,7 +765,7 @@ func (p *pgClientImpl) bulkDeleteGrandparent(
 	res, err := p.db.ExecContext(
 		ctx,
 		`DELETE FROM grandparents WHERE "id" = ANY($1)`,
-		pq.Array(ids),
+		pgtypes.Array(ids),
 	)
 	if err != nil {
 		return err
@@ -954,7 +954,7 @@ func (p *pgClientImpl) privateGrandparentFillParents(
 		`SELECT * FROM parents
 		 WHERE "grandparent_id" = ANY($1)
 		 `,
-		pq.Array(ids),
+		pgtypes.Array(ids),
 	)
 	if err != nil {
 		return err
@@ -1051,7 +1051,7 @@ func (p *pgClientImpl) privateGrandparentFillParentFavoriteGrandkid(
 			ctx,
 			`SELECT * FROM children
 			WHERE id = ANY($1)`,
-			pq.Array(ids),
+			pgtypes.Array(ids),
 		)
 		if err != nil {
 			return err
@@ -1148,7 +1148,7 @@ func (p *pgClientImpl) listParent(
 	rows, err := p.queryContext(
 		ctx,
 		`SELECT * FROM parents WHERE "id" = ANY($1)`,
-		pq.Array(ids),
+		pgtypes.Array(ids),
 	)
 	if err != nil {
 		return nil, err
@@ -1725,7 +1725,7 @@ func (p *pgClientImpl) bulkDeleteParent(
 	res, err := p.db.ExecContext(
 		ctx,
 		`DELETE FROM parents WHERE "id" = ANY($1)`,
-		pq.Array(ids),
+		pgtypes.Array(ids),
 	)
 	if err != nil {
 		return err
@@ -1914,7 +1914,7 @@ func (p *pgClientImpl) privateParentFillChildren(
 		`SELECT * FROM children
 		 WHERE "parent_id" = ANY($1)
 		 `,
-		pq.Array(ids),
+		pgtypes.Array(ids),
 	)
 	if err != nil {
 		return err
@@ -2005,7 +2005,7 @@ func (p *pgClientImpl) privateParentFillParentGrandparent(
 			ctx,
 			`SELECT * FROM grandparents
 			WHERE id = ANY($1)`,
-			pq.Array(ids),
+			pgtypes.Array(ids),
 		)
 		if err != nil {
 			return err
@@ -2102,7 +2102,7 @@ func (p *pgClientImpl) listChild(
 	rows, err := p.queryContext(
 		ctx,
 		`SELECT * FROM children WHERE "id" = ANY($1)`,
-		pq.Array(ids),
+		pgtypes.Array(ids),
 	)
 	if err != nil {
 		return nil, err
@@ -2679,7 +2679,7 @@ func (p *pgClientImpl) bulkDeleteChild(
 	res, err := p.db.ExecContext(
 		ctx,
 		`DELETE FROM children WHERE "id" = ANY($1)`,
-		pq.Array(ids),
+		pgtypes.Array(ids),
 	)
 	if err != nil {
 		return err
@@ -2871,7 +2871,7 @@ func (p *pgClientImpl) privateChildFillDarlingGrandparents(
 		`SELECT * FROM grandparents
 		 WHERE "favorite_grandkid_id" = ANY($1)
 		 `,
-		pq.Array(ids),
+		pgtypes.Array(ids),
 	)
 	if err != nil {
 		return err
@@ -2963,7 +2963,7 @@ func (p *pgClientImpl) privateChildFillParentParent(
 			ctx,
 			`SELECT * FROM parents
 			WHERE id = ANY($1)`,
-			pq.Array(ids),
+			pgtypes.Array(ids),
 		)
 		if err != nil {
 			return err

--- a/examples/json_columns/models/models.gen.go
+++ b/examples/json_columns/models/models.gen.go
@@ -8,7 +8,7 @@ import (
 	"database/sql/driver"
 	"encoding/json"
 	"fmt"
-	"github.com/lib/pq"
+	"github.com/ethanpailes/pgtypes"
 	"github.com/opendoor-labs/pggen"
 	"github.com/opendoor-labs/pggen/examples/json_columns/config"
 	"github.com/opendoor-labs/pggen/include"
@@ -187,7 +187,7 @@ func (p *pgClientImpl) listUser(
 	rows, err := p.queryContext(
 		ctx,
 		`SELECT * FROM users WHERE "id" = ANY($1)`,
-		pq.Array(ids),
+		pgtypes.Array(ids),
 	)
 	if err != nil {
 		return nil, err
@@ -794,7 +794,7 @@ func (p *pgClientImpl) bulkDeleteUser(
 	res, err := p.db.ExecContext(
 		ctx,
 		`DELETE FROM users WHERE "id" = ANY($1)`,
-		pq.Array(ids),
+		pgtypes.Array(ids),
 	)
 	if err != nil {
 		return err

--- a/examples/middleware/models/models.gen.go
+++ b/examples/middleware/models/models.gen.go
@@ -6,7 +6,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"github.com/lib/pq"
+	"github.com/ethanpailes/pgtypes"
 	"github.com/opendoor-labs/pggen"
 	"github.com/opendoor-labs/pggen/include"
 	"github.com/opendoor-labs/pggen/unstable"
@@ -184,7 +184,7 @@ func (p *pgClientImpl) listFoo(
 	rows, err := p.queryContext(
 		ctx,
 		`SELECT * FROM foos WHERE "id" = ANY($1)`,
-		pq.Array(ids),
+		pgtypes.Array(ids),
 	)
 	if err != nil {
 		return nil, err
@@ -746,7 +746,7 @@ func (p *pgClientImpl) bulkDeleteFoo(
 	res, err := p.db.ExecContext(
 		ctx,
 		`DELETE FROM foos WHERE "id" = ANY($1)`,
-		pq.Array(ids),
+		pgtypes.Array(ids),
 	)
 	if err != nil {
 		return err

--- a/examples/nullable_query_arguments/models/models.gen.go
+++ b/examples/nullable_query_arguments/models/models.gen.go
@@ -6,7 +6,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"github.com/lib/pq"
+	"github.com/ethanpailes/pgtypes"
 	"github.com/opendoor-labs/pggen"
 	"github.com/opendoor-labs/pggen/include"
 	"github.com/opendoor-labs/pggen/unstable"
@@ -186,7 +186,7 @@ func (p *pgClientImpl) listUser(
 	rows, err := p.queryContext(
 		ctx,
 		`SELECT * FROM users WHERE "id" = ANY($1)`,
-		pq.Array(ids),
+		pgtypes.Array(ids),
 	)
 	if err != nil {
 		return nil, err
@@ -763,7 +763,7 @@ func (p *pgClientImpl) bulkDeleteUser(
 	res, err := p.db.ExecContext(
 		ctx,
 		`DELETE FROM users WHERE "id" = ANY($1)`,
-		pq.Array(ids),
+		pgtypes.Array(ids),
 	)
 	if err != nil {
 		return err

--- a/examples/query/models/models.gen.go
+++ b/examples/query/models/models.gen.go
@@ -6,7 +6,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"github.com/lib/pq"
+	"github.com/ethanpailes/pgtypes"
 	"github.com/opendoor-labs/pggen"
 	"github.com/opendoor-labs/pggen/include"
 	"github.com/opendoor-labs/pggen/unstable"
@@ -188,7 +188,7 @@ func (p *pgClientImpl) listUser(
 	rows, err := p.queryContext(
 		ctx,
 		`SELECT * FROM users WHERE "id" = ANY($1)`,
-		pq.Array(ids),
+		pgtypes.Array(ids),
 	)
 	if err != nil {
 		return nil, err
@@ -765,7 +765,7 @@ func (p *pgClientImpl) bulkDeleteUser(
 	res, err := p.db.ExecContext(
 		ctx,
 		`DELETE FROM users WHERE "id" = ANY($1)`,
-		pq.Array(ids),
+		pgtypes.Array(ids),
 	)
 	if err != nil {
 		return err

--- a/examples/query_argument_names/models/models.gen.go
+++ b/examples/query_argument_names/models/models.gen.go
@@ -6,7 +6,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"github.com/lib/pq"
+	"github.com/ethanpailes/pgtypes"
 	"github.com/opendoor-labs/pggen"
 	"github.com/opendoor-labs/pggen/include"
 	"github.com/opendoor-labs/pggen/unstable"
@@ -186,7 +186,7 @@ func (p *pgClientImpl) listUser(
 	rows, err := p.queryContext(
 		ctx,
 		`SELECT * FROM users WHERE "id" = ANY($1)`,
-		pq.Array(ids),
+		pgtypes.Array(ids),
 	)
 	if err != nil {
 		return nil, err
@@ -763,7 +763,7 @@ func (p *pgClientImpl) bulkDeleteUser(
 	res, err := p.db.ExecContext(
 		ctx,
 		`DELETE FROM users WHERE "id" = ANY($1)`,
-		pq.Array(ids),
+		pgtypes.Array(ids),
 	)
 	if err != nil {
 		return err

--- a/examples/single_results/models/models.gen.go
+++ b/examples/single_results/models/models.gen.go
@@ -6,7 +6,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"github.com/lib/pq"
+	"github.com/ethanpailes/pgtypes"
 	"github.com/opendoor-labs/pggen"
 	"github.com/opendoor-labs/pggen/include"
 	"github.com/opendoor-labs/pggen/unstable"
@@ -186,7 +186,7 @@ func (p *pgClientImpl) listFoo(
 	rows, err := p.queryContext(
 		ctx,
 		`SELECT * FROM foos WHERE "id" = ANY($1)`,
-		pq.Array(ids),
+		pgtypes.Array(ids),
 	)
 	if err != nil {
 		return nil, err
@@ -748,7 +748,7 @@ func (p *pgClientImpl) bulkDeleteFoo(
 	res, err := p.db.ExecContext(
 		ctx,
 		`DELETE FROM foos WHERE "id" = ANY($1)`,
-		pq.Array(ids),
+		pgtypes.Array(ids),
 	)
 	if err != nil {
 		return err

--- a/examples/statement/models/models.gen.go
+++ b/examples/statement/models/models.gen.go
@@ -6,7 +6,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"github.com/lib/pq"
+	"github.com/ethanpailes/pgtypes"
 	"github.com/opendoor-labs/pggen"
 	"github.com/opendoor-labs/pggen/include"
 	"github.com/opendoor-labs/pggen/unstable"
@@ -184,7 +184,7 @@ func (p *pgClientImpl) listUser(
 	rows, err := p.queryContext(
 		ctx,
 		`SELECT * FROM users WHERE "id" = ANY($1)`,
-		pq.Array(ids),
+		pgtypes.Array(ids),
 	)
 	if err != nil {
 		return nil, err
@@ -761,7 +761,7 @@ func (p *pgClientImpl) bulkDeleteUser(
 	res, err := p.db.ExecContext(
 		ctx,
 		`DELETE FROM users WHERE "id" = ANY($1)`,
-		pq.Array(ids),
+		pgtypes.Array(ids),
 	)
 	if err != nil {
 		return err

--- a/examples/timestamps/models/models.gen.go
+++ b/examples/timestamps/models/models.gen.go
@@ -6,7 +6,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"github.com/lib/pq"
+	"github.com/ethanpailes/pgtypes"
 	"github.com/opendoor-labs/pggen"
 	"github.com/opendoor-labs/pggen/include"
 	"github.com/opendoor-labs/pggen/unstable"
@@ -187,7 +187,7 @@ func (p *pgClientImpl) listUser(
 	rows, err := p.queryContext(
 		ctx,
 		`SELECT * FROM users WHERE "id" = ANY($1) AND "deleted_at" IS NULL `,
-		pq.Array(ids),
+		pgtypes.Array(ids),
 	)
 	if err != nil {
 		return nil, err
@@ -823,14 +823,14 @@ func (p *pgClientImpl) bulkDeleteUser(
 		res, err = p.db.ExecContext(
 			ctx,
 			`DELETE FROM users WHERE "id" = ANY($1)`,
-			pq.Array(ids),
+			pgtypes.Array(ids),
 		)
 	} else {
 		res, err = p.db.ExecContext(
 			ctx,
 			`UPDATE users SET "deleted_at" = $1 WHERE "id" = ANY($2)`,
 			now,
-			pq.Array(ids),
+			pgtypes.Array(ids),
 		)
 	}
 	if err != nil {

--- a/examples/upsert/main.go
+++ b/examples/upsert/main.go
@@ -15,7 +15,7 @@ import (
 func main() {
 	ctx := context.Background()
 
-	conn, err := sql.Open("postgres", os.Getenv("DB_URL"))
+	conn, err := sql.Open("pgx", os.Getenv("DB_URL"))
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/examples/upsert/models/models.gen.go
+++ b/examples/upsert/models/models.gen.go
@@ -6,7 +6,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"github.com/lib/pq"
+	"github.com/ethanpailes/pgtypes"
 	"github.com/opendoor-labs/pggen"
 	"github.com/opendoor-labs/pggen/include"
 	"github.com/opendoor-labs/pggen/unstable"
@@ -184,7 +184,7 @@ func (p *pgClientImpl) listUser(
 	rows, err := p.queryContext(
 		ctx,
 		`SELECT * FROM users WHERE "id" = ANY($1)`,
-		pq.Array(ids),
+		pgtypes.Array(ids),
 	)
 	if err != nil {
 		return nil, err
@@ -776,7 +776,7 @@ func (p *pgClientImpl) bulkDeleteUser(
 	res, err := p.db.ExecContext(
 		ctx,
 		`DELETE FROM users WHERE "id" = ANY($1)`,
-		pq.Array(ids),
+		pgtypes.Array(ids),
 	)
 	if err != nil {
 		return err

--- a/gen/gen_table.go
+++ b/gen/gen_table.go
@@ -22,7 +22,7 @@ func (g *Generator) genTables(into io.Writer, tables []config.TableConfig) error
 	g.imports[`"fmt"`] = true
 	g.imports[`"strings"`] = true
 	g.imports[`"sync"`] = true
-	g.imports[`"github.com/lib/pq"`] = true
+	g.imports[`"github.com/ethanpailes/pgtypes"`] = true
 	g.imports[`"github.com/opendoor-labs/pggen/include"`] = true
 	g.imports[`"github.com/opendoor-labs/pggen/unstable"`] = true
 	g.imports[`"github.com/opendoor-labs/pggen"`] = true
@@ -156,7 +156,7 @@ func (p *pgClientImpl) list{{ .GoName }}(
 		ctx,
 		` + "`" + `SELECT * FROM {{ .PgName }} WHERE "{{ .PkeyCol.PgName }}" = ANY($1)
 		{{- if .Meta.HasDeletedAtField }} AND "{{ .Meta.PgDeletedAtField }}" IS NULL {{ end }}` + "`" + `,
-		pq.Array(ids),
+		pgtypes.Array(ids),
 	)
 	if err != nil {
 		return nil, err
@@ -852,21 +852,21 @@ func (p *pgClientImpl) bulkDelete{{ .GoName }}(
 		res, err = p.db.ExecContext(
 			ctx,
 			` + "`" + `DELETE FROM {{ .PgName }} WHERE "{{ .PkeyCol.PgName }}" = ANY($1)` + "`" + `,
-			pq.Array(ids),
+			pgtypes.Array(ids),
 		)
 	} else {
 		res, err = p.db.ExecContext(
 			ctx,
 			` + "`" + `UPDATE {{ .PgName }} SET "{{ .Meta.PgDeletedAtField }}" = $1 WHERE "{{ .PkeyCol.PgName }}" = ANY($2)` + "`" + `,
 			now,
-			pq.Array(ids),
+			pgtypes.Array(ids),
 		)
 	}
 	{{- else }}
 	res, err := p.db.ExecContext(
 		ctx,
 		` + "`" + `DELETE FROM {{ .PgName }} WHERE "{{ .PkeyCol.PgName }}" = ANY($1)` + "`" + `,
-		pq.Array(ids),
+		pgtypes.Array(ids),
 	)
 	{{- end }}
 	if err != nil {
@@ -1081,7 +1081,7 @@ func (p *pgClientImpl) private{{ $.GoName }}Fill{{ .GoPointsFromFieldName }}(
 		 {{- if .PointsFrom.HasDeletedAtField }} AND "{{ .PointsFrom.PgDeletedAtField }}" IS NULL {{- end }}
 		 ` +
 	"`" + `,
-		pq.Array(ids),
+		pgtypes.Array(ids),
 	)
 	if err != nil {
 		return err
@@ -1207,7 +1207,7 @@ func (p *pgClientImpl) private{{ $.GoName }}FillParent{{ .GoPointsToFieldName }}
 			WHERE {{ .PointsToField.PgName }} = ANY($1)
 		 {{- if .PointsTo.HasDeletedAtField }} AND "{{ .PointsTo.PgDeletedAtField }}" IS NULL {{- end -}}
 		 ` + "`" + `,
-			pq.Array(ids),
+			pgtypes.Array(ids),
 		)
 		if err != nil {
 			return err

--- a/gen/internal/meta/table_meta.go
+++ b/gen/internal/meta/table_meta.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 	"text/template"
 
+	"github.com/ethanpailes/pgtypes"
 	"github.com/jinzhu/inflection"
-	"github.com/lib/pq"
 
 	"github.com/opendoor-labs/pggen/gen/internal/config"
 	"github.com/opendoor-labs/pggen/gen/internal/log"
@@ -835,8 +835,8 @@ func (tr *tableResolver) fillTableReferences(meta *PgTableInfo) error {
 		)
 
 		err = rows.Scan(
-			&pgPointsToSchema, &pgPointsToTable, pq.Array(&pointsToIdxs),
-			&pgPointsFromSchema, &pgPointsFromTable, pq.Array(&pointsFromIdxs),
+			&pgPointsToSchema, &pgPointsToTable, pgtypes.Array(&pointsToIdxs),
+			&pgPointsFromSchema, &pgPointsFromTable, pgtypes.Array(&pointsFromIdxs),
 		)
 		if err != nil {
 			return err

--- a/gen/internal/types/gen_enum.go
+++ b/gen/internal/types/gen_enum.go
@@ -103,7 +103,7 @@ func stringizeArrayWrap(variable string) string {
 			for _, e := range %s {
 				ret = append(ret, e.String())
 			}
-			return pq.Array(ret)
+			return pgtypes.Array(ret)
 		}()`, variable, variable)
 }
 

--- a/gen/internal/types/types.go
+++ b/gen/internal/types/types.go
@@ -255,11 +255,11 @@ func refWrap(variable string) string {
 }
 
 func arrayWrap(variable string) string {
-	return fmt.Sprintf("pq.Array(%s)", variable)
+	return fmt.Sprintf("pgtypes.Array(%s)", variable)
 }
 
 func arrayRefWrap(variable string) string {
-	return fmt.Sprintf("pq.Array(&(%s))", variable)
+	return fmt.Sprintf("pgtypes.Array(&(%s))", variable)
 }
 
 func convertCall(fun string) func(string) string {

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.13
 
 require (
 	github.com/BurntSushi/toml v0.3.1
+	github.com/ethanpailes/pgtypes v0.0.0-20210319175856-9f6ab13c3655
 	github.com/google/uuid v1.1.1
 	github.com/jackc/pgconn v1.8.0
 	github.com/jackc/pgproto3/v2 v2.0.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -12,6 +12,8 @@ github.com/denisenkom/go-mssqldb v0.0.0-20191124224453-732737034ffd h1:83Wprp6RO
 github.com/denisenkom/go-mssqldb v0.0.0-20191124224453-732737034ffd/go.mod h1:xbL0rPBG9cCiLr28tMa8zpbdarY27NDyej4t/EjAShU=
 github.com/erikstmartin/go-testdb v0.0.0-20160219214506-8d10e4a1bae5 h1:Yzb9+7DPaBjB8zlTR87/ElzFsnQfuHnVUVqpZZIcV5Y=
 github.com/erikstmartin/go-testdb v0.0.0-20160219214506-8d10e4a1bae5/go.mod h1:a2zkGnVExMxdzMo3M0Hi/3sEU+cWnZpSni0O6/Yb/P0=
+github.com/ethanpailes/pgtypes v0.0.0-20210319175856-9f6ab13c3655 h1:nlmK0KuP6zerVMkJr/ZRulYTrlhCz2Eb3oZ1YnEu0lk=
+github.com/ethanpailes/pgtypes v0.0.0-20210319175856-9f6ab13c3655/go.mod h1:MexWJIrcOXnIod3yV2Tslh1C/3GlKdRTQi0gBhxgjjI=
 github.com/go-sql-driver/mysql v1.4.1 h1:g24URVg0OFbNUTx9qqY1IRZ9D9z3iPyi5zKhQZpNwpA=
 github.com/go-sql-driver/mysql v1.4.1/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
@@ -34,8 +36,6 @@ github.com/jackc/pgconn v0.0.0-20190831204454-2fabfa3c18b7/go.mod h1:ZJKsE/KZfsU
 github.com/jackc/pgconn v1.4.0/go.mod h1:Y2O3ZDF0q4mMacyWV3AstPJpeHXWGEetiFttmq5lahk=
 github.com/jackc/pgconn v1.5.0/go.mod h1:QeD3lBfpTFe8WUnPZWN5KY/mB8FGMIYRdd8P8Jr0fAI=
 github.com/jackc/pgconn v1.5.1-0.20200601181101-fa742c524853/go.mod h1:QeD3lBfpTFe8WUnPZWN5KY/mB8FGMIYRdd8P8Jr0fAI=
-github.com/jackc/pgconn v1.7.0 h1:pwjzcYyfmz/HQOQlENvG1OcDqauTGaqlVahq934F0/U=
-github.com/jackc/pgconn v1.7.0/go.mod h1:sF/lPpNEMEOp+IYhyQGdAvrG20gWf6A1tKlr0v7JMeA=
 github.com/jackc/pgconn v1.8.0 h1:FmjZ0rOyXTr1wfWs45i4a9vjnjWUAGpMuQLD9OSs+lw=
 github.com/jackc/pgconn v1.8.0/go.mod h1:1C2Pb36bGIP9QHGBYCjnyhqu7Rv3sGshaQUvmfGIB/o=
 github.com/jackc/pgio v1.0.0 h1:g12B9UwVnzGhueNavwioyEEpAmqMe1E/BN9ES+8ovkE=
@@ -51,9 +51,6 @@ github.com/jackc/pgproto3/v2 v2.0.0-alpha1.0.20190609003834-432c2951c711/go.mod 
 github.com/jackc/pgproto3/v2 v2.0.0-rc3/go.mod h1:ryONWYqW6dqSg1Lw6vXNMXoBJhpzvWKnT95C46ckYeM=
 github.com/jackc/pgproto3/v2 v2.0.0-rc3.0.20190831210041-4c03ce451f29/go.mod h1:ryONWYqW6dqSg1Lw6vXNMXoBJhpzvWKnT95C46ckYeM=
 github.com/jackc/pgproto3/v2 v2.0.1/go.mod h1:WfJCnwN3HIg9Ish/j3sgWXnAfK8A9Y0bwXYU5xKaEdA=
-github.com/jackc/pgproto3/v2 v2.0.5 h1:NUbEWPmCQZbMmYlTjVoNPhc0CfnYyz2bfUAh6A5ZVJM=
-github.com/jackc/pgproto3/v2 v2.0.5/go.mod h1:WfJCnwN3HIg9Ish/j3sgWXnAfK8A9Y0bwXYU5xKaEdA=
-github.com/jackc/pgproto3/v2 v2.0.6 h1:b1105ZGEMFe7aCvrT1Cca3VoVb4ZFMaFJLJcg/3zD+8=
 github.com/jackc/pgproto3/v2 v2.0.6/go.mod h1:WfJCnwN3HIg9Ish/j3sgWXnAfK8A9Y0bwXYU5xKaEdA=
 github.com/jackc/pgproto3/v2 v2.0.7 h1:6Pwi1b3QdY65cuv6SyVO0FgPd5J3Bl7wf/nQQjinHMA=
 github.com/jackc/pgproto3/v2 v2.0.7/go.mod h1:WfJCnwN3HIg9Ish/j3sgWXnAfK8A9Y0bwXYU5xKaEdA=
@@ -66,8 +63,6 @@ github.com/jackc/pgtype v0.0.0-20190828014616-a8802b16cc59/go.mod h1:MWlu30kVJrU
 github.com/jackc/pgtype v1.2.0/go.mod h1:5m2OfMh1wTK7x+Fk952IDmI4nw3nPrvtQdM0ZT4WpC0=
 github.com/jackc/pgtype v1.3.1-0.20200510190516-8cd94a14c75a/go.mod h1:vaogEUkALtxZMCH411K+tKzNpwzCKU+AnPzBKZ+I+Po=
 github.com/jackc/pgtype v1.3.1-0.20200606141011-f6355165a91c/go.mod h1:cvk9Bgu/VzJ9/lxTO5R5sf80p0DiucVtN7ZxvaC4GmQ=
-github.com/jackc/pgtype v1.5.0 h1:jzBqRk2HFG2CV4AIwgCI2PwTgm6UUoCAK2ofHHRirtc=
-github.com/jackc/pgtype v1.5.0/go.mod h1:JCULISAZBFGrHaOXIIFiyfzW5VY0GRitRr8NeJsrdig=
 github.com/jackc/pgtype v1.6.2 h1:b3pDeuhbbzBYcg5kwNmNDun4pFUD/0AAr1kLXZLeNt8=
 github.com/jackc/pgtype v1.6.2/go.mod h1:JCULISAZBFGrHaOXIIFiyfzW5VY0GRitRr8NeJsrdig=
 github.com/jackc/pgx/v4 v4.0.0-20190420224344-cc3461e65d96/go.mod h1:mdxmSJJuR08CZQyj1PVQBHy9XOp5p8/SHH6a0psbY9Y=
@@ -76,15 +71,12 @@ github.com/jackc/pgx/v4 v4.0.0-pre1.0.20190824185557-6972a5742186/go.mod h1:X+GQ
 github.com/jackc/pgx/v4 v4.5.0/go.mod h1:EpAKPLdnTorwmPUUsqrPxy5fphV18j9q3wrfRXgo+kA=
 github.com/jackc/pgx/v4 v4.6.1-0.20200510190926-94ba730bb1e9/go.mod h1:t3/cdRQl6fOLDxqtlyhe9UWgfIi9R8+8v8GKV5TRA/o=
 github.com/jackc/pgx/v4 v4.6.1-0.20200606145419-4e5062306904/go.mod h1:ZDaNWkt9sW1JMiNn0kdYBaLelIhw7Pg4qd+Vk6tw7Hg=
-github.com/jackc/pgx/v4 v4.9.0 h1:6STjDqppM2ROy5p1wNDcsC7zJTjSHeuCsguZmXyzx7c=
-github.com/jackc/pgx/v4 v4.9.0/go.mod h1:MNGWmViCgqbZck9ujOOBN63gK9XVGILXWCvKLGKmnms=
 github.com/jackc/pgx/v4 v4.10.1 h1:/6Q3ye4myIj6AaplUm+eRcz4OhK9HAvFf4ePsG40LJY=
 github.com/jackc/pgx/v4 v4.10.1/go.mod h1:QlrWebbs3kqEZPHCTGyxecvzG6tvIsYu+A5b1raylkA=
 github.com/jackc/puddle v0.0.0-20190413234325-e4ced69a3a2b/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jackc/puddle v0.0.0-20190608224051-11cab39313c9/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jackc/puddle v1.1.0/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jackc/puddle v1.1.1/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
-github.com/jackc/puddle v1.1.2/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jackc/puddle v1.1.3/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jinzhu/gorm v1.9.12 h1:Drgk1clyWT9t9ERbzHza6Mj/8FY/CqMyVzOiHviMo6Q=
 github.com/jinzhu/gorm v1.9.12/go.mod h1:vhTjlKSJUTWNtcbQtrMBFCxy7eXTzeCAzfL5fBZT/Qs=
@@ -160,7 +152,6 @@ golang.org/x/crypto v0.0.0-20190820162420-60c769a6c586/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20190911031432-227b76d455e7/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191205180655-e7c4368fe9dd/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200323165209-0ec3e9974c59/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
-golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9 h1:psW17arqaxU48Z5kZ0CQnkZWQJsqcURM6tKiBApRjXI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20210317152858-513c2a44f670 h1:gzMM0EjIYiRmJI3+jBdFuoynZlpxa2JQZsolKu09BXo=
 golang.org/x/crypto v0.0.0-20210317152858-513c2a44f670/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
@@ -187,7 +178,6 @@ golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
-golang.org/x/text v0.3.3 h1:cokOdA+Jmi5PJGXLlLllQSgYigAEfHXJAERHVMaCc2k=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.5 h1:i6eZZ+zk0SOf0xgBpEpPD18qWcJda6q1sxt3S0kzyUQ=
 golang.org/x/text v0.3.5/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
@@ -201,7 +191,6 @@ golang.org/x/tools v0.0.0-20191029190741-b9c20aec41a5/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/xerrors v0.0.0-20190410155217-1f06c39b4373/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20190513163551-3ee3066db522/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/tools/ensure-schema/lib/lib.go
+++ b/tools/ensure-schema/lib/lib.go
@@ -7,7 +7,7 @@ import (
 	"io/ioutil"
 	"os"
 
-	_ "github.com/lib/pq" // load postgres driver
+	_ "github.com/jackc/pgx/v4/stdlib" // load postgres driver
 )
 
 // PopulateDB runs `schemaFilePath` against `$DB_URL`
@@ -29,7 +29,7 @@ func PopulateDB(schemaFilePath string) error {
 	if !inEnv {
 		return fmt.Errorf("populateDB: DB_URL must be present in the environment")
 	}
-	db, err := sql.Open("postgres", dbURL)
+	db, err := sql.Open("pgx", dbURL)
 	if err != nil {
 		return fmt.Errorf("populateDB: opening connection to database: %s", err.Error())
 	}


### PR DESCRIPTION
This patch switches the generated code over to
use ethanpailes/pgtypes rather than lib/pq for
array scanning and fixes a few dangling odds and
ends where there were still references to lib/pq.

Closes #155