### PR TITLE
fix colliding field names for multiple refs

### DIFF
--- a/cmd/pggen/test/db.sql
+++ b/cmd/pggen/test/db.sql
@@ -100,7 +100,6 @@ CREATE TABLE type_rainbow (
     -- TODO: bit string types
     -- TODO: text search types
     -- TODO: XML type
-    -- TODO: arrays
     -- TODO: composite types
     -- TODO: range types
     -- TODO: object identifier types
@@ -387,6 +386,12 @@ CREATE TABLE json_values (
     json_field_not_null json NOT NULL,
     jsonb_field jsonb,
     jsonb_field_not_null jsonb NOT NULL
+);
+
+CREATE TABLE double_references (
+    id SERIAL PRIMARY KEY,
+    sekey1 int NOT NULL REFERENCES small_entities(id) ON UPDATE CASCADE,
+    sekey2 int NOT NULL REFERENCES small_entities(id) ON UPDATE CASCADE
 );
 
 --

--- a/cmd/pggen/test/models/pggen.toml
+++ b/cmd/pggen/test/models/pggen.toml
@@ -558,6 +558,9 @@
 [[table]]
     name = "simple_enums"
 
+[[table]]
+    name = "double_references"
+
 ####################################################################################
 #                                                                                  #
 #                                     otherschema                                  #


### PR DESCRIPTION
This patch teaches pggen to handle the case where a child
table wants to reference a single parent table via two different
foreign key columns. The fix is to just disambiguate the names
when we recognize this case.

Fixes #159