### PR TITLE
IsNotFoundError: check causal chain as well

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -9,7 +9,27 @@ import (
 // file: errors.go
 // This file defines error utility functions used by pggen.
 
+// IsNotFoundError returns true if the given error, or any of its causes
+// is a not found error returned from pggen. The causal chain is determined
+// by repeatedly calling Unwrap on the error.
 func IsNotFoundError(err error) bool {
-	_, is := err.(*unstable.NotFoundError)
-	return is
+	for {
+		if err == nil {
+			return false
+		}
+
+		_, is := err.(*unstable.NotFoundError)
+		if is {
+			return is
+		}
+
+		// we don't use errors.Unwrap in order to maintain our msgv
+		u, ok := err.(interface {
+			Unwrap() error
+		})
+		if !ok {
+			return false
+		}
+		err = u.Unwrap()
+	}
 }

--- a/errors_test.go
+++ b/errors_test.go
@@ -1,0 +1,56 @@
+// (c) 2021 Opendoor Labs Inc.
+// This code is licenced under the MIT licence (see the LICENCE file in the repo root).
+package pggen
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/opendoor-labs/pggen/unstable"
+)
+
+func TestIsNotFoundError(t *testing.T) {
+	type testCase struct {
+		err error
+		is  bool
+	}
+	cases := []testCase{
+		{
+			err: fmt.Errorf("NonNotFound1"),
+			is:  false,
+		},
+		{
+			err: &unstable.NotFoundError{Msg: "NotFound1"},
+			is:  true,
+		},
+		{
+			err: &causedErr{cause: &unstable.NotFoundError{Msg: "NotFound2"}},
+			is:  true,
+		},
+		{
+			err: &causedErr{cause: fmt.Errorf("NonNotFound2")},
+			is:  false,
+		},
+	}
+
+	for i := range cases {
+		c := cases[i]
+		t.Run(c.err.Error(), func(t *testing.T) {
+			if IsNotFoundError(c.err) != c.is {
+				t.Fatalf("expected %t, got %t", c.is, !c.is)
+			}
+		})
+	}
+}
+
+// we define this manually rather than using %w to maintain our msgv
+type causedErr struct {
+	cause error
+}
+
+func (ce *causedErr) Error() string {
+	return ce.cause.Error()
+}
+func (ce *causedErr) Unwrap() error {
+	return ce.cause
+}


### PR DESCRIPTION
This is a breaking change, but it shouldn't impact any
current existing usage. This will be nice because it means
you can intercept not-found errors in middleware and wrap them
with your own error tagging system and calls to IsNotFoundError
in your existing codebase should continue to work.

This also makes us match the behavior of errors.Is from the standard
library better, which ought to be less confusing given the name
of the function.