### PR TITLE
middleware: add support for error converter func

### DIFF
--- a/examples/extending_models/models/models.gen.go
+++ b/examples/extending_models/models/models.gen.go
@@ -21,6 +21,8 @@ type PGClient struct {
 	impl       pgClientImpl
 	topLevelDB pggen.DBConn
 
+	errorConverter func(error) error
+
 	// These column indexes are used at run time to enable us to 'SELECT *' against
 	// a table that has the same columns in a different order from the ones that we
 	// saw in the table we used to generate code. This means that you don't have to worry
@@ -39,6 +41,12 @@ var _ = sync.RWMutex{}
 // If you provide your own wrapper around a '*sql.DB' for logging or
 // custom tracing, you MUST forward all calls to an underlying '*sql.DB'
 // member of your wrapper.
+//
+// If the DBConn passed into NewPGClient implements an ErrorConverter
+// method which returns a func(error) error, the result of calling the
+// ErrorConverter method will be called on every error that the generated
+// code returns right before the error is returned. If ErrorConverter
+// returns nil or is not present, it will default to the identity function.
 func NewPGClient(conn pggen.DBConn) *PGClient {
 	client := PGClient{
 		topLevelDB: conn,
@@ -46,6 +54,17 @@ func NewPGClient(conn pggen.DBConn) *PGClient {
 	client.impl = pgClientImpl{
 		db:     conn,
 		client: &client,
+	}
+
+	// extract the optional error converter routine
+	ec, ok := conn.(interface {
+		ErrorConverter() func(error) error
+	})
+	if ok {
+		client.errorConverter = ec.ErrorConverter()
+	}
+	if client.errorConverter == nil {
+		client.errorConverter = func(err error) error { return err }
 	}
 
 	return &client
@@ -58,7 +77,7 @@ func (p *PGClient) Handle() pggen.DBHandle {
 func (p *PGClient) BeginTx(ctx context.Context, opts *sql.TxOptions) (*TxPGClient, error) {
 	tx, err := p.topLevelDB.BeginTx(ctx, opts)
 	if err != nil {
-		return nil, err
+		return nil, p.errorConverter(err)
 	}
 
 	return &TxPGClient{
@@ -72,7 +91,7 @@ func (p *PGClient) BeginTx(ctx context.Context, opts *sql.TxOptions) (*TxPGClien
 func (p *PGClient) Conn(ctx context.Context) (*ConnPGClient, error) {
 	conn, err := p.topLevelDB.Conn(ctx)
 	if err != nil {
-		return nil, err
+		return nil, p.errorConverter(err)
 	}
 
 	return &ConnPGClient{impl: pgClientImpl{db: conn, client: p}}, nil
@@ -188,18 +207,19 @@ func (p *pgClientImpl) listDog(
 		pgtypes.Array(ids),
 	)
 	if err != nil {
-		return nil, err
+		return nil, p.client.errorConverter(err)
 	}
 	defer func() {
 		if err == nil {
 			err = rows.Close()
 			if err != nil {
 				ret = nil
+				err = p.client.errorConverter(err)
 			}
 		} else {
 			rowErr := rows.Close()
 			if rowErr != nil {
-				err = fmt.Errorf("%s AND %s", err.Error(), rowErr.Error())
+				err = p.client.errorConverter(fmt.Errorf("%s AND %s", err.Error(), rowErr.Error()))
 			}
 		}
 	}()
@@ -209,24 +229,24 @@ func (p *pgClientImpl) listDog(
 		var value Dog
 		err = value.Scan(ctx, p.client, rows)
 		if err != nil {
-			return nil, err
+			return nil, p.client.errorConverter(err)
 		}
 		ret = append(ret, value)
 	}
 
 	if len(ret) != len(ids) {
 		if isGet {
-			return nil, &unstable.NotFoundError{
+			return nil, p.client.errorConverter(&unstable.NotFoundError{
 				Msg: "GetDog: record not found",
-			}
+			})
 		} else {
-			return nil, &unstable.NotFoundError{
+			return nil, p.client.errorConverter(&unstable.NotFoundError{
 				Msg: fmt.Sprintf(
 					"ListDog: asked for %d records, found %d",
 					len(ids),
 					len(ret),
 				),
-			}
+			})
 		}
 	}
 
@@ -273,12 +293,11 @@ func (p *pgClientImpl) insertDog(
 	var ids []int64
 	ids, err = p.bulkInsertDog(ctx, []Dog{*value}, opts...)
 	if err != nil {
-		return
+		return ret, p.client.errorConverter(err)
 	}
 
 	if len(ids) != 1 {
-		err = fmt.Errorf("inserting a Dog: %d ids (expected 1)", len(ids))
-		return
+		return ret, p.client.errorConverter(fmt.Errorf("inserting a Dog: %d ids (expected 1)", len(ids)))
 	}
 
 	ret = ids[0]
@@ -359,7 +378,7 @@ func (p *pgClientImpl) bulkInsertDog(
 
 	rows, err := p.queryContext(ctx, bulkInsertQuery, args...)
 	if err != nil {
-		return nil, err
+		return nil, p.client.errorConverter(err)
 	}
 	defer rows.Close()
 
@@ -368,7 +387,7 @@ func (p *pgClientImpl) bulkInsertDog(
 		var id int64
 		err = rows.Scan(&(id))
 		if err != nil {
-			return nil, err
+			return nil, p.client.errorConverter(err)
 		}
 		ids = append(ids, id)
 	}
@@ -450,8 +469,7 @@ func (p *pgClientImpl) updateDog(
 	opts ...pggen.UpdateOpt,
 ) (ret int64, err error) {
 	if !fieldMask.Test(DogIdFieldIndex) {
-		err = fmt.Errorf(`primary key required for updates to 'dogs'`)
-		return
+		return ret, p.client.errorConverter(fmt.Errorf(`primary key required for updates to 'dogs'`))
 	}
 
 	updateStmt := genUpdateStmt(
@@ -483,7 +501,7 @@ func (p *pgClientImpl) updateDog(
 	err = p.db.QueryRowContext(ctx, updateStmt, args...).
 		Scan(&(id))
 	if err != nil {
-		return
+		return ret, p.client.errorConverter(err)
 	}
 
 	return id, nil
@@ -701,7 +719,7 @@ func (p *pgClientImpl) bulkUpsertDog(
 
 	rows, err := p.queryContext(ctx, stmt.String(), args...)
 	if err != nil {
-		return nil, err
+		return nil, p.client.errorConverter(err)
 	}
 	defer rows.Close()
 
@@ -710,7 +728,7 @@ func (p *pgClientImpl) bulkUpsertDog(
 		var id int64
 		err = rows.Scan(&(id))
 		if err != nil {
-			return nil, err
+			return nil, p.client.errorConverter(err)
 		}
 		ids = append(ids, id)
 	}
@@ -780,20 +798,20 @@ func (p *pgClientImpl) bulkDeleteDog(
 		pgtypes.Array(ids),
 	)
 	if err != nil {
-		return err
+		return p.client.errorConverter(err)
 	}
 
 	nrows, err := res.RowsAffected()
 	if err != nil {
-		return err
+		return p.client.errorConverter(err)
 	}
 
 	if nrows != int64(len(ids)) {
-		return fmt.Errorf(
+		return p.client.errorConverter(fmt.Errorf(
 			"BulkDeleteDog: %d rows deleted, expected %d",
 			nrows,
 			len(ids),
-		)
+		))
 	}
 
 	return err
@@ -870,10 +888,10 @@ func (p *pgClientImpl) implDogBulkFillIncludes(
 	loadedRecordTab map[string]interface{},
 ) (err error) {
 	if includes.TableName != `dogs` {
-		return fmt.Errorf(
+		return p.client.errorConverter(fmt.Errorf(
 			`expected includes for 'dogs', got '%s'`,
 			includes.TableName,
-		)
+		))
 	}
 
 	loadedTab, inMap := loadedRecordTab[`dogs`]

--- a/examples/json_columns/models/models.gen.go
+++ b/examples/json_columns/models/models.gen.go
@@ -23,6 +23,8 @@ type PGClient struct {
 	impl       pgClientImpl
 	topLevelDB pggen.DBConn
 
+	errorConverter func(error) error
+
 	// These column indexes are used at run time to enable us to 'SELECT *' against
 	// a table that has the same columns in a different order from the ones that we
 	// saw in the table we used to generate code. This means that you don't have to worry
@@ -41,6 +43,12 @@ var _ = sync.RWMutex{}
 // If you provide your own wrapper around a '*sql.DB' for logging or
 // custom tracing, you MUST forward all calls to an underlying '*sql.DB'
 // member of your wrapper.
+//
+// If the DBConn passed into NewPGClient implements an ErrorConverter
+// method which returns a func(error) error, the result of calling the
+// ErrorConverter method will be called on every error that the generated
+// code returns right before the error is returned. If ErrorConverter
+// returns nil or is not present, it will default to the identity function.
 func NewPGClient(conn pggen.DBConn) *PGClient {
 	client := PGClient{
 		topLevelDB: conn,
@@ -48,6 +56,17 @@ func NewPGClient(conn pggen.DBConn) *PGClient {
 	client.impl = pgClientImpl{
 		db:     conn,
 		client: &client,
+	}
+
+	// extract the optional error converter routine
+	ec, ok := conn.(interface {
+		ErrorConverter() func(error) error
+	})
+	if ok {
+		client.errorConverter = ec.ErrorConverter()
+	}
+	if client.errorConverter == nil {
+		client.errorConverter = func(err error) error { return err }
 	}
 
 	return &client
@@ -60,7 +79,7 @@ func (p *PGClient) Handle() pggen.DBHandle {
 func (p *PGClient) BeginTx(ctx context.Context, opts *sql.TxOptions) (*TxPGClient, error) {
 	tx, err := p.topLevelDB.BeginTx(ctx, opts)
 	if err != nil {
-		return nil, err
+		return nil, p.errorConverter(err)
 	}
 
 	return &TxPGClient{
@@ -74,7 +93,7 @@ func (p *PGClient) BeginTx(ctx context.Context, opts *sql.TxOptions) (*TxPGClien
 func (p *PGClient) Conn(ctx context.Context) (*ConnPGClient, error) {
 	conn, err := p.topLevelDB.Conn(ctx)
 	if err != nil {
-		return nil, err
+		return nil, p.errorConverter(err)
 	}
 
 	return &ConnPGClient{impl: pgClientImpl{db: conn, client: p}}, nil
@@ -190,18 +209,19 @@ func (p *pgClientImpl) listUser(
 		pgtypes.Array(ids),
 	)
 	if err != nil {
-		return nil, err
+		return nil, p.client.errorConverter(err)
 	}
 	defer func() {
 		if err == nil {
 			err = rows.Close()
 			if err != nil {
 				ret = nil
+				err = p.client.errorConverter(err)
 			}
 		} else {
 			rowErr := rows.Close()
 			if rowErr != nil {
-				err = fmt.Errorf("%s AND %s", err.Error(), rowErr.Error())
+				err = p.client.errorConverter(fmt.Errorf("%s AND %s", err.Error(), rowErr.Error()))
 			}
 		}
 	}()
@@ -211,24 +231,24 @@ func (p *pgClientImpl) listUser(
 		var value User
 		err = value.Scan(ctx, p.client, rows)
 		if err != nil {
-			return nil, err
+			return nil, p.client.errorConverter(err)
 		}
 		ret = append(ret, value)
 	}
 
 	if len(ret) != len(ids) {
 		if isGet {
-			return nil, &unstable.NotFoundError{
+			return nil, p.client.errorConverter(&unstable.NotFoundError{
 				Msg: "GetUser: record not found",
-			}
+			})
 		} else {
-			return nil, &unstable.NotFoundError{
+			return nil, p.client.errorConverter(&unstable.NotFoundError{
 				Msg: fmt.Sprintf(
 					"ListUser: asked for %d records, found %d",
 					len(ids),
 					len(ret),
 				),
-			}
+			})
 		}
 	}
 
@@ -275,12 +295,11 @@ func (p *pgClientImpl) insertUser(
 	var ids []int64
 	ids, err = p.bulkInsertUser(ctx, []User{*value}, opts...)
 	if err != nil {
-		return
+		return ret, p.client.errorConverter(err)
 	}
 
 	if len(ids) != 1 {
-		err = fmt.Errorf("inserting a User: %d ids (expected 1)", len(ids))
-		return
+		return ret, p.client.errorConverter(fmt.Errorf("inserting a User: %d ids (expected 1)", len(ids)))
 	}
 
 	ret = ids[0]
@@ -364,7 +383,7 @@ func (p *pgClientImpl) bulkInsertUser(
 
 	rows, err := p.queryContext(ctx, bulkInsertQuery, args...)
 	if err != nil {
-		return nil, err
+		return nil, p.client.errorConverter(err)
 	}
 	defer rows.Close()
 
@@ -373,7 +392,7 @@ func (p *pgClientImpl) bulkInsertUser(
 		var id int64
 		err = rows.Scan(&(id))
 		if err != nil {
-			return nil, err
+			return nil, p.client.errorConverter(err)
 		}
 		ids = append(ids, id)
 	}
@@ -457,8 +476,7 @@ func (p *pgClientImpl) updateUser(
 	opts ...pggen.UpdateOpt,
 ) (ret int64, err error) {
 	if !fieldMask.Test(UserIdFieldIndex) {
-		err = fmt.Errorf(`primary key required for updates to 'users'`)
-		return
+		return ret, p.client.errorConverter(fmt.Errorf(`primary key required for updates to 'users'`))
 	}
 
 	updateStmt := genUpdateStmt(
@@ -493,7 +511,7 @@ func (p *pgClientImpl) updateUser(
 	err = p.db.QueryRowContext(ctx, updateStmt, args...).
 		Scan(&(id))
 	if err != nil {
-		return
+		return ret, p.client.errorConverter(err)
 	}
 
 	return id, nil
@@ -718,7 +736,7 @@ func (p *pgClientImpl) bulkUpsertUser(
 
 	rows, err := p.queryContext(ctx, stmt.String(), args...)
 	if err != nil {
-		return nil, err
+		return nil, p.client.errorConverter(err)
 	}
 	defer rows.Close()
 
@@ -727,7 +745,7 @@ func (p *pgClientImpl) bulkUpsertUser(
 		var id int64
 		err = rows.Scan(&(id))
 		if err != nil {
-			return nil, err
+			return nil, p.client.errorConverter(err)
 		}
 		ids = append(ids, id)
 	}
@@ -797,20 +815,20 @@ func (p *pgClientImpl) bulkDeleteUser(
 		pgtypes.Array(ids),
 	)
 	if err != nil {
-		return err
+		return p.client.errorConverter(err)
 	}
 
 	nrows, err := res.RowsAffected()
 	if err != nil {
-		return err
+		return p.client.errorConverter(err)
 	}
 
 	if nrows != int64(len(ids)) {
-		return fmt.Errorf(
+		return p.client.errorConverter(fmt.Errorf(
 			"BulkDeleteUser: %d rows deleted, expected %d",
 			nrows,
 			len(ids),
-		)
+		))
 	}
 
 	return err
@@ -887,10 +905,10 @@ func (p *pgClientImpl) implUserBulkFillIncludes(
 	loadedRecordTab map[string]interface{},
 ) (err error) {
 	if includes.TableName != `users` {
-		return fmt.Errorf(
+		return p.client.errorConverter(fmt.Errorf(
 			`expected includes for 'users', got '%s'`,
 			includes.TableName,
-		)
+		))
 	}
 
 	loadedTab, inMap := loadedRecordTab[`users`]

--- a/examples/middleware/models/models.gen.go
+++ b/examples/middleware/models/models.gen.go
@@ -20,6 +20,8 @@ type PGClient struct {
 	impl       pgClientImpl
 	topLevelDB pggen.DBConn
 
+	errorConverter func(error) error
+
 	// These column indexes are used at run time to enable us to 'SELECT *' against
 	// a table that has the same columns in a different order from the ones that we
 	// saw in the table we used to generate code. This means that you don't have to worry
@@ -38,6 +40,12 @@ var _ = sync.RWMutex{}
 // If you provide your own wrapper around a '*sql.DB' for logging or
 // custom tracing, you MUST forward all calls to an underlying '*sql.DB'
 // member of your wrapper.
+//
+// If the DBConn passed into NewPGClient implements an ErrorConverter
+// method which returns a func(error) error, the result of calling the
+// ErrorConverter method will be called on every error that the generated
+// code returns right before the error is returned. If ErrorConverter
+// returns nil or is not present, it will default to the identity function.
 func NewPGClient(conn pggen.DBConn) *PGClient {
 	client := PGClient{
 		topLevelDB: conn,
@@ -45,6 +53,17 @@ func NewPGClient(conn pggen.DBConn) *PGClient {
 	client.impl = pgClientImpl{
 		db:     conn,
 		client: &client,
+	}
+
+	// extract the optional error converter routine
+	ec, ok := conn.(interface {
+		ErrorConverter() func(error) error
+	})
+	if ok {
+		client.errorConverter = ec.ErrorConverter()
+	}
+	if client.errorConverter == nil {
+		client.errorConverter = func(err error) error { return err }
 	}
 
 	return &client
@@ -57,7 +76,7 @@ func (p *PGClient) Handle() pggen.DBHandle {
 func (p *PGClient) BeginTx(ctx context.Context, opts *sql.TxOptions) (*TxPGClient, error) {
 	tx, err := p.topLevelDB.BeginTx(ctx, opts)
 	if err != nil {
-		return nil, err
+		return nil, p.errorConverter(err)
 	}
 
 	return &TxPGClient{
@@ -71,7 +90,7 @@ func (p *PGClient) BeginTx(ctx context.Context, opts *sql.TxOptions) (*TxPGClien
 func (p *PGClient) Conn(ctx context.Context) (*ConnPGClient, error) {
 	conn, err := p.topLevelDB.Conn(ctx)
 	if err != nil {
-		return nil, err
+		return nil, p.errorConverter(err)
 	}
 
 	return &ConnPGClient{impl: pgClientImpl{db: conn, client: p}}, nil
@@ -187,18 +206,19 @@ func (p *pgClientImpl) listFoo(
 		pgtypes.Array(ids),
 	)
 	if err != nil {
-		return nil, err
+		return nil, p.client.errorConverter(err)
 	}
 	defer func() {
 		if err == nil {
 			err = rows.Close()
 			if err != nil {
 				ret = nil
+				err = p.client.errorConverter(err)
 			}
 		} else {
 			rowErr := rows.Close()
 			if rowErr != nil {
-				err = fmt.Errorf("%s AND %s", err.Error(), rowErr.Error())
+				err = p.client.errorConverter(fmt.Errorf("%s AND %s", err.Error(), rowErr.Error()))
 			}
 		}
 	}()
@@ -208,24 +228,24 @@ func (p *pgClientImpl) listFoo(
 		var value Foo
 		err = value.Scan(ctx, p.client, rows)
 		if err != nil {
-			return nil, err
+			return nil, p.client.errorConverter(err)
 		}
 		ret = append(ret, value)
 	}
 
 	if len(ret) != len(ids) {
 		if isGet {
-			return nil, &unstable.NotFoundError{
+			return nil, p.client.errorConverter(&unstable.NotFoundError{
 				Msg: "GetFoo: record not found",
-			}
+			})
 		} else {
-			return nil, &unstable.NotFoundError{
+			return nil, p.client.errorConverter(&unstable.NotFoundError{
 				Msg: fmt.Sprintf(
 					"ListFoo: asked for %d records, found %d",
 					len(ids),
 					len(ret),
 				),
-			}
+			})
 		}
 	}
 
@@ -272,12 +292,11 @@ func (p *pgClientImpl) insertFoo(
 	var ids []int64
 	ids, err = p.bulkInsertFoo(ctx, []Foo{*value}, opts...)
 	if err != nil {
-		return
+		return ret, p.client.errorConverter(err)
 	}
 
 	if len(ids) != 1 {
-		err = fmt.Errorf("inserting a Foo: %d ids (expected 1)", len(ids))
-		return
+		return ret, p.client.errorConverter(fmt.Errorf("inserting a Foo: %d ids (expected 1)", len(ids)))
 	}
 
 	ret = ids[0]
@@ -352,7 +371,7 @@ func (p *pgClientImpl) bulkInsertFoo(
 
 	rows, err := p.queryContext(ctx, bulkInsertQuery, args...)
 	if err != nil {
-		return nil, err
+		return nil, p.client.errorConverter(err)
 	}
 	defer rows.Close()
 
@@ -361,7 +380,7 @@ func (p *pgClientImpl) bulkInsertFoo(
 		var id int64
 		err = rows.Scan(&(id))
 		if err != nil {
-			return nil, err
+			return nil, p.client.errorConverter(err)
 		}
 		ids = append(ids, id)
 	}
@@ -439,8 +458,7 @@ func (p *pgClientImpl) updateFoo(
 	opts ...pggen.UpdateOpt,
 ) (ret int64, err error) {
 	if !fieldMask.Test(FooIdFieldIndex) {
-		err = fmt.Errorf(`primary key required for updates to 'foos'`)
-		return
+		return ret, p.client.errorConverter(fmt.Errorf(`primary key required for updates to 'foos'`))
 	}
 
 	updateStmt := genUpdateStmt(
@@ -466,7 +484,7 @@ func (p *pgClientImpl) updateFoo(
 	err = p.db.QueryRowContext(ctx, updateStmt, args...).
 		Scan(&(id))
 	if err != nil {
-		return
+		return ret, p.client.errorConverter(err)
 	}
 
 	return id, nil
@@ -670,7 +688,7 @@ func (p *pgClientImpl) bulkUpsertFoo(
 
 	rows, err := p.queryContext(ctx, stmt.String(), args...)
 	if err != nil {
-		return nil, err
+		return nil, p.client.errorConverter(err)
 	}
 	defer rows.Close()
 
@@ -679,7 +697,7 @@ func (p *pgClientImpl) bulkUpsertFoo(
 		var id int64
 		err = rows.Scan(&(id))
 		if err != nil {
-			return nil, err
+			return nil, p.client.errorConverter(err)
 		}
 		ids = append(ids, id)
 	}
@@ -749,20 +767,20 @@ func (p *pgClientImpl) bulkDeleteFoo(
 		pgtypes.Array(ids),
 	)
 	if err != nil {
-		return err
+		return p.client.errorConverter(err)
 	}
 
 	nrows, err := res.RowsAffected()
 	if err != nil {
-		return err
+		return p.client.errorConverter(err)
 	}
 
 	if nrows != int64(len(ids)) {
-		return fmt.Errorf(
+		return p.client.errorConverter(fmt.Errorf(
 			"BulkDeleteFoo: %d rows deleted, expected %d",
 			nrows,
 			len(ids),
-		)
+		))
 	}
 
 	return err
@@ -839,10 +857,10 @@ func (p *pgClientImpl) implFooBulkFillIncludes(
 	loadedRecordTab map[string]interface{},
 ) (err error) {
 	if includes.TableName != `foos` {
-		return fmt.Errorf(
+		return p.client.errorConverter(fmt.Errorf(
 			`expected includes for 'foos', got '%s'`,
 			includes.TableName,
-		)
+		))
 	}
 
 	loadedTab, inMap := loadedRecordTab[`foos`]

--- a/examples/middleware/output.txt
+++ b/examples/middleware/output.txt
@@ -9,3 +9,5 @@ ExecContext query: DELETE FROM foos WHERE "id" = ANY($1)
 QueryContext query: SELECT * FROM foos WHERE "id" = ANY($1)
 bax
 lish
+QueryContext query: SELECT * FROM foos WHERE "id" = ANY($1)
+GetErr: My Not Found Error

--- a/examples/query/models/models.gen.go
+++ b/examples/query/models/models.gen.go
@@ -20,6 +20,8 @@ type PGClient struct {
 	impl       pgClientImpl
 	topLevelDB pggen.DBConn
 
+	errorConverter func(error) error
+
 	// These column indexes are used at run time to enable us to 'SELECT *' against
 	// a table that has the same columns in a different order from the ones that we
 	// saw in the table we used to generate code. This means that you don't have to worry
@@ -42,6 +44,12 @@ var _ = sync.RWMutex{}
 // If you provide your own wrapper around a '*sql.DB' for logging or
 // custom tracing, you MUST forward all calls to an underlying '*sql.DB'
 // member of your wrapper.
+//
+// If the DBConn passed into NewPGClient implements an ErrorConverter
+// method which returns a func(error) error, the result of calling the
+// ErrorConverter method will be called on every error that the generated
+// code returns right before the error is returned. If ErrorConverter
+// returns nil or is not present, it will default to the identity function.
 func NewPGClient(conn pggen.DBConn) *PGClient {
 	client := PGClient{
 		topLevelDB: conn,
@@ -49,6 +57,17 @@ func NewPGClient(conn pggen.DBConn) *PGClient {
 	client.impl = pgClientImpl{
 		db:     conn,
 		client: &client,
+	}
+
+	// extract the optional error converter routine
+	ec, ok := conn.(interface {
+		ErrorConverter() func(error) error
+	})
+	if ok {
+		client.errorConverter = ec.ErrorConverter()
+	}
+	if client.errorConverter == nil {
+		client.errorConverter = func(err error) error { return err }
 	}
 
 	return &client
@@ -61,7 +80,7 @@ func (p *PGClient) Handle() pggen.DBHandle {
 func (p *PGClient) BeginTx(ctx context.Context, opts *sql.TxOptions) (*TxPGClient, error) {
 	tx, err := p.topLevelDB.BeginTx(ctx, opts)
 	if err != nil {
-		return nil, err
+		return nil, p.errorConverter(err)
 	}
 
 	return &TxPGClient{
@@ -75,7 +94,7 @@ func (p *PGClient) BeginTx(ctx context.Context, opts *sql.TxOptions) (*TxPGClien
 func (p *PGClient) Conn(ctx context.Context) (*ConnPGClient, error) {
 	conn, err := p.topLevelDB.Conn(ctx)
 	if err != nil {
-		return nil, err
+		return nil, p.errorConverter(err)
 	}
 
 	return &ConnPGClient{impl: pgClientImpl{db: conn, client: p}}, nil
@@ -191,18 +210,19 @@ func (p *pgClientImpl) listUser(
 		pgtypes.Array(ids),
 	)
 	if err != nil {
-		return nil, err
+		return nil, p.client.errorConverter(err)
 	}
 	defer func() {
 		if err == nil {
 			err = rows.Close()
 			if err != nil {
 				ret = nil
+				err = p.client.errorConverter(err)
 			}
 		} else {
 			rowErr := rows.Close()
 			if rowErr != nil {
-				err = fmt.Errorf("%s AND %s", err.Error(), rowErr.Error())
+				err = p.client.errorConverter(fmt.Errorf("%s AND %s", err.Error(), rowErr.Error()))
 			}
 		}
 	}()
@@ -212,24 +232,24 @@ func (p *pgClientImpl) listUser(
 		var value User
 		err = value.Scan(ctx, p.client, rows)
 		if err != nil {
-			return nil, err
+			return nil, p.client.errorConverter(err)
 		}
 		ret = append(ret, value)
 	}
 
 	if len(ret) != len(ids) {
 		if isGet {
-			return nil, &unstable.NotFoundError{
+			return nil, p.client.errorConverter(&unstable.NotFoundError{
 				Msg: "GetUser: record not found",
-			}
+			})
 		} else {
-			return nil, &unstable.NotFoundError{
+			return nil, p.client.errorConverter(&unstable.NotFoundError{
 				Msg: fmt.Sprintf(
 					"ListUser: asked for %d records, found %d",
 					len(ids),
 					len(ret),
 				),
-			}
+			})
 		}
 	}
 
@@ -276,12 +296,11 @@ func (p *pgClientImpl) insertUser(
 	var ids []int64
 	ids, err = p.bulkInsertUser(ctx, []User{*value}, opts...)
 	if err != nil {
-		return
+		return ret, p.client.errorConverter(err)
 	}
 
 	if len(ids) != 1 {
-		err = fmt.Errorf("inserting a User: %d ids (expected 1)", len(ids))
-		return
+		return ret, p.client.errorConverter(fmt.Errorf("inserting a User: %d ids (expected 1)", len(ids)))
 	}
 
 	ret = ids[0]
@@ -359,7 +378,7 @@ func (p *pgClientImpl) bulkInsertUser(
 
 	rows, err := p.queryContext(ctx, bulkInsertQuery, args...)
 	if err != nil {
-		return nil, err
+		return nil, p.client.errorConverter(err)
 	}
 	defer rows.Close()
 
@@ -368,7 +387,7 @@ func (p *pgClientImpl) bulkInsertUser(
 		var id int64
 		err = rows.Scan(&(id))
 		if err != nil {
-			return nil, err
+			return nil, p.client.errorConverter(err)
 		}
 		ids = append(ids, id)
 	}
@@ -448,8 +467,7 @@ func (p *pgClientImpl) updateUser(
 	opts ...pggen.UpdateOpt,
 ) (ret int64, err error) {
 	if !fieldMask.Test(UserIdFieldIndex) {
-		err = fmt.Errorf(`primary key required for updates to 'users'`)
-		return
+		return ret, p.client.errorConverter(fmt.Errorf(`primary key required for updates to 'users'`))
 	}
 
 	updateStmt := genUpdateStmt(
@@ -478,7 +496,7 @@ func (p *pgClientImpl) updateUser(
 	err = p.db.QueryRowContext(ctx, updateStmt, args...).
 		Scan(&(id))
 	if err != nil {
-		return
+		return ret, p.client.errorConverter(err)
 	}
 
 	return id, nil
@@ -689,7 +707,7 @@ func (p *pgClientImpl) bulkUpsertUser(
 
 	rows, err := p.queryContext(ctx, stmt.String(), args...)
 	if err != nil {
-		return nil, err
+		return nil, p.client.errorConverter(err)
 	}
 	defer rows.Close()
 
@@ -698,7 +716,7 @@ func (p *pgClientImpl) bulkUpsertUser(
 		var id int64
 		err = rows.Scan(&(id))
 		if err != nil {
-			return nil, err
+			return nil, p.client.errorConverter(err)
 		}
 		ids = append(ids, id)
 	}
@@ -768,20 +786,20 @@ func (p *pgClientImpl) bulkDeleteUser(
 		pgtypes.Array(ids),
 	)
 	if err != nil {
-		return err
+		return p.client.errorConverter(err)
 	}
 
 	nrows, err := res.RowsAffected()
 	if err != nil {
-		return err
+		return p.client.errorConverter(err)
 	}
 
 	if nrows != int64(len(ids)) {
-		return fmt.Errorf(
+		return p.client.errorConverter(fmt.Errorf(
 			"BulkDeleteUser: %d rows deleted, expected %d",
 			nrows,
 			len(ids),
-		)
+		))
 	}
 
 	return err
@@ -858,10 +876,10 @@ func (p *pgClientImpl) implUserBulkFillIncludes(
 	loadedRecordTab map[string]interface{},
 ) (err error) {
 	if includes.TableName != `users` {
-		return fmt.Errorf(
+		return p.client.errorConverter(fmt.Errorf(
 			`expected includes for 'users', got '%s'`,
 			includes.TableName,
-		)
+		))
 	}
 
 	loadedTab, inMap := loadedRecordTab[`users`]
@@ -928,18 +946,19 @@ func (p *pgClientImpl) GetUserNicknameAndEmail(
 		arg1,
 	)
 	if err != nil {
-		return nil, err
+		return nil, p.client.errorConverter(err)
 	}
 	defer func() {
 		if err == nil {
 			err = rows.Close()
 			if err != nil {
 				ret = nil
+				err = p.client.errorConverter(err)
 			}
 		} else {
 			rowErr := rows.Close()
 			if rowErr != nil {
-				err = fmt.Errorf("%s AND %s", err.Error(), rowErr.Error())
+				err = p.client.errorConverter(fmt.Errorf("%s AND %s", err.Error(), rowErr.Error()))
 			}
 		}
 	}()
@@ -1043,18 +1062,19 @@ func (p *pgClientImpl) MyGetUser(
 		arg1,
 	)
 	if err != nil {
-		return nil, err
+		return nil, p.client.errorConverter(err)
 	}
 	defer func() {
 		if err == nil {
 			err = rows.Close()
 			if err != nil {
 				ret = nil
+				err = p.client.errorConverter(err)
 			}
 		} else {
 			rowErr := rows.Close()
 			if rowErr != nil {
-				err = fmt.Errorf("%s AND %s", err.Error(), rowErr.Error())
+				err = p.client.errorConverter(fmt.Errorf("%s AND %s", err.Error(), rowErr.Error()))
 			}
 		}
 	}()

--- a/examples/query_argument_names/models/models.gen.go
+++ b/examples/query_argument_names/models/models.gen.go
@@ -20,6 +20,8 @@ type PGClient struct {
 	impl       pgClientImpl
 	topLevelDB pggen.DBConn
 
+	errorConverter func(error) error
+
 	// These column indexes are used at run time to enable us to 'SELECT *' against
 	// a table that has the same columns in a different order from the ones that we
 	// saw in the table we used to generate code. This means that you don't have to worry
@@ -40,6 +42,12 @@ var _ = sync.RWMutex{}
 // If you provide your own wrapper around a '*sql.DB' for logging or
 // custom tracing, you MUST forward all calls to an underlying '*sql.DB'
 // member of your wrapper.
+//
+// If the DBConn passed into NewPGClient implements an ErrorConverter
+// method which returns a func(error) error, the result of calling the
+// ErrorConverter method will be called on every error that the generated
+// code returns right before the error is returned. If ErrorConverter
+// returns nil or is not present, it will default to the identity function.
 func NewPGClient(conn pggen.DBConn) *PGClient {
 	client := PGClient{
 		topLevelDB: conn,
@@ -47,6 +55,17 @@ func NewPGClient(conn pggen.DBConn) *PGClient {
 	client.impl = pgClientImpl{
 		db:     conn,
 		client: &client,
+	}
+
+	// extract the optional error converter routine
+	ec, ok := conn.(interface {
+		ErrorConverter() func(error) error
+	})
+	if ok {
+		client.errorConverter = ec.ErrorConverter()
+	}
+	if client.errorConverter == nil {
+		client.errorConverter = func(err error) error { return err }
 	}
 
 	return &client
@@ -59,7 +78,7 @@ func (p *PGClient) Handle() pggen.DBHandle {
 func (p *PGClient) BeginTx(ctx context.Context, opts *sql.TxOptions) (*TxPGClient, error) {
 	tx, err := p.topLevelDB.BeginTx(ctx, opts)
 	if err != nil {
-		return nil, err
+		return nil, p.errorConverter(err)
 	}
 
 	return &TxPGClient{
@@ -73,7 +92,7 @@ func (p *PGClient) BeginTx(ctx context.Context, opts *sql.TxOptions) (*TxPGClien
 func (p *PGClient) Conn(ctx context.Context) (*ConnPGClient, error) {
 	conn, err := p.topLevelDB.Conn(ctx)
 	if err != nil {
-		return nil, err
+		return nil, p.errorConverter(err)
 	}
 
 	return &ConnPGClient{impl: pgClientImpl{db: conn, client: p}}, nil
@@ -189,18 +208,19 @@ func (p *pgClientImpl) listUser(
 		pgtypes.Array(ids),
 	)
 	if err != nil {
-		return nil, err
+		return nil, p.client.errorConverter(err)
 	}
 	defer func() {
 		if err == nil {
 			err = rows.Close()
 			if err != nil {
 				ret = nil
+				err = p.client.errorConverter(err)
 			}
 		} else {
 			rowErr := rows.Close()
 			if rowErr != nil {
-				err = fmt.Errorf("%s AND %s", err.Error(), rowErr.Error())
+				err = p.client.errorConverter(fmt.Errorf("%s AND %s", err.Error(), rowErr.Error()))
 			}
 		}
 	}()
@@ -210,24 +230,24 @@ func (p *pgClientImpl) listUser(
 		var value User
 		err = value.Scan(ctx, p.client, rows)
 		if err != nil {
-			return nil, err
+			return nil, p.client.errorConverter(err)
 		}
 		ret = append(ret, value)
 	}
 
 	if len(ret) != len(ids) {
 		if isGet {
-			return nil, &unstable.NotFoundError{
+			return nil, p.client.errorConverter(&unstable.NotFoundError{
 				Msg: "GetUser: record not found",
-			}
+			})
 		} else {
-			return nil, &unstable.NotFoundError{
+			return nil, p.client.errorConverter(&unstable.NotFoundError{
 				Msg: fmt.Sprintf(
 					"ListUser: asked for %d records, found %d",
 					len(ids),
 					len(ret),
 				),
-			}
+			})
 		}
 	}
 
@@ -274,12 +294,11 @@ func (p *pgClientImpl) insertUser(
 	var ids []int64
 	ids, err = p.bulkInsertUser(ctx, []User{*value}, opts...)
 	if err != nil {
-		return
+		return ret, p.client.errorConverter(err)
 	}
 
 	if len(ids) != 1 {
-		err = fmt.Errorf("inserting a User: %d ids (expected 1)", len(ids))
-		return
+		return ret, p.client.errorConverter(fmt.Errorf("inserting a User: %d ids (expected 1)", len(ids)))
 	}
 
 	ret = ids[0]
@@ -357,7 +376,7 @@ func (p *pgClientImpl) bulkInsertUser(
 
 	rows, err := p.queryContext(ctx, bulkInsertQuery, args...)
 	if err != nil {
-		return nil, err
+		return nil, p.client.errorConverter(err)
 	}
 	defer rows.Close()
 
@@ -366,7 +385,7 @@ func (p *pgClientImpl) bulkInsertUser(
 		var id int64
 		err = rows.Scan(&(id))
 		if err != nil {
-			return nil, err
+			return nil, p.client.errorConverter(err)
 		}
 		ids = append(ids, id)
 	}
@@ -446,8 +465,7 @@ func (p *pgClientImpl) updateUser(
 	opts ...pggen.UpdateOpt,
 ) (ret int64, err error) {
 	if !fieldMask.Test(UserIdFieldIndex) {
-		err = fmt.Errorf(`primary key required for updates to 'users'`)
-		return
+		return ret, p.client.errorConverter(fmt.Errorf(`primary key required for updates to 'users'`))
 	}
 
 	updateStmt := genUpdateStmt(
@@ -476,7 +494,7 @@ func (p *pgClientImpl) updateUser(
 	err = p.db.QueryRowContext(ctx, updateStmt, args...).
 		Scan(&(id))
 	if err != nil {
-		return
+		return ret, p.client.errorConverter(err)
 	}
 
 	return id, nil
@@ -687,7 +705,7 @@ func (p *pgClientImpl) bulkUpsertUser(
 
 	rows, err := p.queryContext(ctx, stmt.String(), args...)
 	if err != nil {
-		return nil, err
+		return nil, p.client.errorConverter(err)
 	}
 	defer rows.Close()
 
@@ -696,7 +714,7 @@ func (p *pgClientImpl) bulkUpsertUser(
 		var id int64
 		err = rows.Scan(&(id))
 		if err != nil {
-			return nil, err
+			return nil, p.client.errorConverter(err)
 		}
 		ids = append(ids, id)
 	}
@@ -766,20 +784,20 @@ func (p *pgClientImpl) bulkDeleteUser(
 		pgtypes.Array(ids),
 	)
 	if err != nil {
-		return err
+		return p.client.errorConverter(err)
 	}
 
 	nrows, err := res.RowsAffected()
 	if err != nil {
-		return err
+		return p.client.errorConverter(err)
 	}
 
 	if nrows != int64(len(ids)) {
-		return fmt.Errorf(
+		return p.client.errorConverter(fmt.Errorf(
 			"BulkDeleteUser: %d rows deleted, expected %d",
 			nrows,
 			len(ids),
-		)
+		))
 	}
 
 	return err
@@ -856,10 +874,10 @@ func (p *pgClientImpl) implUserBulkFillIncludes(
 	loadedRecordTab map[string]interface{},
 ) (err error) {
 	if includes.TableName != `users` {
-		return fmt.Errorf(
+		return p.client.errorConverter(fmt.Errorf(
 			`expected includes for 'users', got '%s'`,
 			includes.TableName,
-		)
+		))
 	}
 
 	loadedTab, inMap := loadedRecordTab[`users`]
@@ -931,18 +949,19 @@ func (p *pgClientImpl) GetUserByEmailOrNickname(
 		nickname,
 	)
 	if err != nil {
-		return nil, err
+		return nil, p.client.errorConverter(err)
 	}
 	defer func() {
 		if err == nil {
 			err = rows.Close()
 			if err != nil {
 				ret = nil
+				err = p.client.errorConverter(err)
 			}
 		} else {
 			rowErr := rows.Close()
 			if rowErr != nil {
-				err = fmt.Errorf("%s AND %s", err.Error(), rowErr.Error())
+				err = p.client.errorConverter(fmt.Errorf("%s AND %s", err.Error(), rowErr.Error()))
 			}
 		}
 	}()
@@ -1035,11 +1054,12 @@ func (p *pgClientImpl) DeleteUsersByNickname(
 	ctx context.Context,
 	nickname string,
 ) (sql.Result, error) {
-	return p.db.ExecContext(
+	res, err := p.db.ExecContext(
 		ctx,
 		`DELETE FROM users WHERE nickname = $1`,
 		nickname,
 	)
+	return res, p.client.errorConverter(err)
 }
 
 type DBQueries interface {

--- a/examples/single_results/models/models.gen.go
+++ b/examples/single_results/models/models.gen.go
@@ -20,6 +20,8 @@ type PGClient struct {
 	impl       pgClientImpl
 	topLevelDB pggen.DBConn
 
+	errorConverter func(error) error
+
 	// These column indexes are used at run time to enable us to 'SELECT *' against
 	// a table that has the same columns in a different order from the ones that we
 	// saw in the table we used to generate code. This means that you don't have to worry
@@ -40,6 +42,12 @@ var _ = sync.RWMutex{}
 // If you provide your own wrapper around a '*sql.DB' for logging or
 // custom tracing, you MUST forward all calls to an underlying '*sql.DB'
 // member of your wrapper.
+//
+// If the DBConn passed into NewPGClient implements an ErrorConverter
+// method which returns a func(error) error, the result of calling the
+// ErrorConverter method will be called on every error that the generated
+// code returns right before the error is returned. If ErrorConverter
+// returns nil or is not present, it will default to the identity function.
 func NewPGClient(conn pggen.DBConn) *PGClient {
 	client := PGClient{
 		topLevelDB: conn,
@@ -47,6 +55,17 @@ func NewPGClient(conn pggen.DBConn) *PGClient {
 	client.impl = pgClientImpl{
 		db:     conn,
 		client: &client,
+	}
+
+	// extract the optional error converter routine
+	ec, ok := conn.(interface {
+		ErrorConverter() func(error) error
+	})
+	if ok {
+		client.errorConverter = ec.ErrorConverter()
+	}
+	if client.errorConverter == nil {
+		client.errorConverter = func(err error) error { return err }
 	}
 
 	return &client
@@ -59,7 +78,7 @@ func (p *PGClient) Handle() pggen.DBHandle {
 func (p *PGClient) BeginTx(ctx context.Context, opts *sql.TxOptions) (*TxPGClient, error) {
 	tx, err := p.topLevelDB.BeginTx(ctx, opts)
 	if err != nil {
-		return nil, err
+		return nil, p.errorConverter(err)
 	}
 
 	return &TxPGClient{
@@ -73,7 +92,7 @@ func (p *PGClient) BeginTx(ctx context.Context, opts *sql.TxOptions) (*TxPGClien
 func (p *PGClient) Conn(ctx context.Context) (*ConnPGClient, error) {
 	conn, err := p.topLevelDB.Conn(ctx)
 	if err != nil {
-		return nil, err
+		return nil, p.errorConverter(err)
 	}
 
 	return &ConnPGClient{impl: pgClientImpl{db: conn, client: p}}, nil
@@ -189,18 +208,19 @@ func (p *pgClientImpl) listFoo(
 		pgtypes.Array(ids),
 	)
 	if err != nil {
-		return nil, err
+		return nil, p.client.errorConverter(err)
 	}
 	defer func() {
 		if err == nil {
 			err = rows.Close()
 			if err != nil {
 				ret = nil
+				err = p.client.errorConverter(err)
 			}
 		} else {
 			rowErr := rows.Close()
 			if rowErr != nil {
-				err = fmt.Errorf("%s AND %s", err.Error(), rowErr.Error())
+				err = p.client.errorConverter(fmt.Errorf("%s AND %s", err.Error(), rowErr.Error()))
 			}
 		}
 	}()
@@ -210,24 +230,24 @@ func (p *pgClientImpl) listFoo(
 		var value Foo
 		err = value.Scan(ctx, p.client, rows)
 		if err != nil {
-			return nil, err
+			return nil, p.client.errorConverter(err)
 		}
 		ret = append(ret, value)
 	}
 
 	if len(ret) != len(ids) {
 		if isGet {
-			return nil, &unstable.NotFoundError{
+			return nil, p.client.errorConverter(&unstable.NotFoundError{
 				Msg: "GetFoo: record not found",
-			}
+			})
 		} else {
-			return nil, &unstable.NotFoundError{
+			return nil, p.client.errorConverter(&unstable.NotFoundError{
 				Msg: fmt.Sprintf(
 					"ListFoo: asked for %d records, found %d",
 					len(ids),
 					len(ret),
 				),
-			}
+			})
 		}
 	}
 
@@ -274,12 +294,11 @@ func (p *pgClientImpl) insertFoo(
 	var ids []int64
 	ids, err = p.bulkInsertFoo(ctx, []Foo{*value}, opts...)
 	if err != nil {
-		return
+		return ret, p.client.errorConverter(err)
 	}
 
 	if len(ids) != 1 {
-		err = fmt.Errorf("inserting a Foo: %d ids (expected 1)", len(ids))
-		return
+		return ret, p.client.errorConverter(fmt.Errorf("inserting a Foo: %d ids (expected 1)", len(ids)))
 	}
 
 	ret = ids[0]
@@ -354,7 +373,7 @@ func (p *pgClientImpl) bulkInsertFoo(
 
 	rows, err := p.queryContext(ctx, bulkInsertQuery, args...)
 	if err != nil {
-		return nil, err
+		return nil, p.client.errorConverter(err)
 	}
 	defer rows.Close()
 
@@ -363,7 +382,7 @@ func (p *pgClientImpl) bulkInsertFoo(
 		var id int64
 		err = rows.Scan(&(id))
 		if err != nil {
-			return nil, err
+			return nil, p.client.errorConverter(err)
 		}
 		ids = append(ids, id)
 	}
@@ -441,8 +460,7 @@ func (p *pgClientImpl) updateFoo(
 	opts ...pggen.UpdateOpt,
 ) (ret int64, err error) {
 	if !fieldMask.Test(FooIdFieldIndex) {
-		err = fmt.Errorf(`primary key required for updates to 'foos'`)
-		return
+		return ret, p.client.errorConverter(fmt.Errorf(`primary key required for updates to 'foos'`))
 	}
 
 	updateStmt := genUpdateStmt(
@@ -468,7 +486,7 @@ func (p *pgClientImpl) updateFoo(
 	err = p.db.QueryRowContext(ctx, updateStmt, args...).
 		Scan(&(id))
 	if err != nil {
-		return
+		return ret, p.client.errorConverter(err)
 	}
 
 	return id, nil
@@ -672,7 +690,7 @@ func (p *pgClientImpl) bulkUpsertFoo(
 
 	rows, err := p.queryContext(ctx, stmt.String(), args...)
 	if err != nil {
-		return nil, err
+		return nil, p.client.errorConverter(err)
 	}
 	defer rows.Close()
 
@@ -681,7 +699,7 @@ func (p *pgClientImpl) bulkUpsertFoo(
 		var id int64
 		err = rows.Scan(&(id))
 		if err != nil {
-			return nil, err
+			return nil, p.client.errorConverter(err)
 		}
 		ids = append(ids, id)
 	}
@@ -751,20 +769,20 @@ func (p *pgClientImpl) bulkDeleteFoo(
 		pgtypes.Array(ids),
 	)
 	if err != nil {
-		return err
+		return p.client.errorConverter(err)
 	}
 
 	nrows, err := res.RowsAffected()
 	if err != nil {
-		return err
+		return p.client.errorConverter(err)
 	}
 
 	if nrows != int64(len(ids)) {
-		return fmt.Errorf(
+		return p.client.errorConverter(fmt.Errorf(
 			"BulkDeleteFoo: %d rows deleted, expected %d",
 			nrows,
 			len(ids),
-		)
+		))
 	}
 
 	return err
@@ -841,10 +859,10 @@ func (p *pgClientImpl) implFooBulkFillIncludes(
 	loadedRecordTab map[string]interface{},
 ) (err error) {
 	if includes.TableName != `foos` {
-		return fmt.Errorf(
+		return p.client.errorConverter(fmt.Errorf(
 			`expected includes for 'foos', got '%s'`,
 			includes.TableName,
-		)
+		))
 	}
 
 	loadedTab, inMap := loadedRecordTab[`foos`]
@@ -912,29 +930,30 @@ func (p *pgClientImpl) MyGetFooValue(
 		arg1,
 	)
 	if err != nil {
-		return zero, err
+		return zero, p.client.errorConverter(err)
 	}
 	defer func() {
 		if err == nil {
 			err = rows.Close()
 			if err != nil {
 				ret = zero
+				err = p.client.errorConverter(err)
 			}
 		} else {
 			rowErr := rows.Close()
 			if rowErr != nil {
-				err = fmt.Errorf("%s AND %s", err.Error(), rowErr.Error())
+				err = p.client.errorConverter(fmt.Errorf("%s AND %s", err.Error(), rowErr.Error()))
 			}
 		}
 	}()
 
 	if !rows.Next() {
-		return zero, &unstable.NotFoundError{Msg: "MyGetFooValue: no results"}
+		return zero, p.client.errorConverter(&unstable.NotFoundError{Msg: "MyGetFooValue: no results"})
 	}
 	var scanTgt sql.NullString
 	err = rows.Scan(&(scanTgt))
 	if err != nil {
-		return zero, err
+		return zero, p.client.errorConverter(err)
 	}
 	ret = convertNullString(scanTgt)
 

--- a/examples/timestamps/models/models.gen.go
+++ b/examples/timestamps/models/models.gen.go
@@ -21,6 +21,8 @@ type PGClient struct {
 	impl       pgClientImpl
 	topLevelDB pggen.DBConn
 
+	errorConverter func(error) error
+
 	// These column indexes are used at run time to enable us to 'SELECT *' against
 	// a table that has the same columns in a different order from the ones that we
 	// saw in the table we used to generate code. This means that you don't have to worry
@@ -41,6 +43,12 @@ var _ = sync.RWMutex{}
 // If you provide your own wrapper around a '*sql.DB' for logging or
 // custom tracing, you MUST forward all calls to an underlying '*sql.DB'
 // member of your wrapper.
+//
+// If the DBConn passed into NewPGClient implements an ErrorConverter
+// method which returns a func(error) error, the result of calling the
+// ErrorConverter method will be called on every error that the generated
+// code returns right before the error is returned. If ErrorConverter
+// returns nil or is not present, it will default to the identity function.
 func NewPGClient(conn pggen.DBConn) *PGClient {
 	client := PGClient{
 		topLevelDB: conn,
@@ -48,6 +56,17 @@ func NewPGClient(conn pggen.DBConn) *PGClient {
 	client.impl = pgClientImpl{
 		db:     conn,
 		client: &client,
+	}
+
+	// extract the optional error converter routine
+	ec, ok := conn.(interface {
+		ErrorConverter() func(error) error
+	})
+	if ok {
+		client.errorConverter = ec.ErrorConverter()
+	}
+	if client.errorConverter == nil {
+		client.errorConverter = func(err error) error { return err }
 	}
 
 	return &client
@@ -60,7 +79,7 @@ func (p *PGClient) Handle() pggen.DBHandle {
 func (p *PGClient) BeginTx(ctx context.Context, opts *sql.TxOptions) (*TxPGClient, error) {
 	tx, err := p.topLevelDB.BeginTx(ctx, opts)
 	if err != nil {
-		return nil, err
+		return nil, p.errorConverter(err)
 	}
 
 	return &TxPGClient{
@@ -74,7 +93,7 @@ func (p *PGClient) BeginTx(ctx context.Context, opts *sql.TxOptions) (*TxPGClien
 func (p *PGClient) Conn(ctx context.Context) (*ConnPGClient, error) {
 	conn, err := p.topLevelDB.Conn(ctx)
 	if err != nil {
-		return nil, err
+		return nil, p.errorConverter(err)
 	}
 
 	return &ConnPGClient{impl: pgClientImpl{db: conn, client: p}}, nil
@@ -190,18 +209,19 @@ func (p *pgClientImpl) listUser(
 		pgtypes.Array(ids),
 	)
 	if err != nil {
-		return nil, err
+		return nil, p.client.errorConverter(err)
 	}
 	defer func() {
 		if err == nil {
 			err = rows.Close()
 			if err != nil {
 				ret = nil
+				err = p.client.errorConverter(err)
 			}
 		} else {
 			rowErr := rows.Close()
 			if rowErr != nil {
-				err = fmt.Errorf("%s AND %s", err.Error(), rowErr.Error())
+				err = p.client.errorConverter(fmt.Errorf("%s AND %s", err.Error(), rowErr.Error()))
 			}
 		}
 	}()
@@ -211,24 +231,24 @@ func (p *pgClientImpl) listUser(
 		var value User
 		err = value.Scan(ctx, p.client, rows)
 		if err != nil {
-			return nil, err
+			return nil, p.client.errorConverter(err)
 		}
 		ret = append(ret, value)
 	}
 
 	if len(ret) != len(ids) {
 		if isGet {
-			return nil, &unstable.NotFoundError{
+			return nil, p.client.errorConverter(&unstable.NotFoundError{
 				Msg: "GetUser: record not found",
-			}
+			})
 		} else {
-			return nil, &unstable.NotFoundError{
+			return nil, p.client.errorConverter(&unstable.NotFoundError{
 				Msg: fmt.Sprintf(
 					"ListUser: asked for %d records, found %d",
 					len(ids),
 					len(ret),
 				),
-			}
+			})
 		}
 	}
 
@@ -275,12 +295,11 @@ func (p *pgClientImpl) insertUser(
 	var ids []int64
 	ids, err = p.bulkInsertUser(ctx, []User{*value}, opts...)
 	if err != nil {
-		return
+		return ret, p.client.errorConverter(err)
 	}
 
 	if len(ids) != 1 {
-		err = fmt.Errorf("inserting a User: %d ids (expected 1)", len(ids))
-		return
+		return ret, p.client.errorConverter(fmt.Errorf("inserting a User: %d ids (expected 1)", len(ids)))
 	}
 
 	ret = ids[0]
@@ -373,7 +392,7 @@ func (p *pgClientImpl) bulkInsertUser(
 
 	rows, err := p.queryContext(ctx, bulkInsertQuery, args...)
 	if err != nil {
-		return nil, err
+		return nil, p.client.errorConverter(err)
 	}
 	defer rows.Close()
 
@@ -382,7 +401,7 @@ func (p *pgClientImpl) bulkInsertUser(
 		var id int64
 		err = rows.Scan(&(id))
 		if err != nil {
-			return nil, err
+			return nil, p.client.errorConverter(err)
 		}
 		ids = append(ids, id)
 	}
@@ -466,8 +485,7 @@ func (p *pgClientImpl) updateUser(
 	opts ...pggen.UpdateOpt,
 ) (ret int64, err error) {
 	if !fieldMask.Test(UserIdFieldIndex) {
-		err = fmt.Errorf(`primary key required for updates to 'users'`)
-		return
+		return ret, p.client.errorConverter(fmt.Errorf(`primary key required for updates to 'users'`))
 	}
 	now := time.Now().UTC()
 	value.UpdatedAt = now
@@ -505,7 +523,7 @@ func (p *pgClientImpl) updateUser(
 	err = p.db.QueryRowContext(ctx, updateStmt, args...).
 		Scan(&(id))
 	if err != nil {
-		return
+		return ret, p.client.errorConverter(err)
 	}
 
 	return id, nil
@@ -741,7 +759,7 @@ func (p *pgClientImpl) bulkUpsertUser(
 
 	rows, err := p.queryContext(ctx, stmt.String(), args...)
 	if err != nil {
-		return nil, err
+		return nil, p.client.errorConverter(err)
 	}
 	defer rows.Close()
 
@@ -750,7 +768,7 @@ func (p *pgClientImpl) bulkUpsertUser(
 		var id int64
 		err = rows.Scan(&(id))
 		if err != nil {
-			return nil, err
+			return nil, p.client.errorConverter(err)
 		}
 		ids = append(ids, id)
 	}
@@ -834,20 +852,20 @@ func (p *pgClientImpl) bulkDeleteUser(
 		)
 	}
 	if err != nil {
-		return err
+		return p.client.errorConverter(err)
 	}
 
 	nrows, err := res.RowsAffected()
 	if err != nil {
-		return err
+		return p.client.errorConverter(err)
 	}
 
 	if nrows != int64(len(ids)) {
-		return fmt.Errorf(
+		return p.client.errorConverter(fmt.Errorf(
 			"BulkDeleteUser: %d rows deleted, expected %d",
 			nrows,
 			len(ids),
-		)
+		))
 	}
 
 	return err
@@ -924,10 +942,10 @@ func (p *pgClientImpl) implUserBulkFillIncludes(
 	loadedRecordTab map[string]interface{},
 ) (err error) {
 	if includes.TableName != `users` {
-		return fmt.Errorf(
+		return p.client.errorConverter(fmt.Errorf(
 			`expected includes for 'users', got '%s'`,
 			includes.TableName,
-		)
+		))
 	}
 
 	loadedTab, inMap := loadedRecordTab[`users`]
@@ -991,18 +1009,19 @@ func (p *pgClientImpl) GetUserAnyway(
 		arg1,
 	)
 	if err != nil {
-		return nil, err
+		return nil, p.client.errorConverter(err)
 	}
 	defer func() {
 		if err == nil {
 			err = rows.Close()
 			if err != nil {
 				ret = nil
+				err = p.client.errorConverter(err)
 			}
 		} else {
 			rowErr := rows.Close()
 			if rowErr != nil {
-				err = fmt.Errorf("%s AND %s", err.Error(), rowErr.Error())
+				err = p.client.errorConverter(fmt.Errorf("%s AND %s", err.Error(), rowErr.Error()))
 			}
 		}
 	}()

--- a/examples/upsert/models/models.gen.go
+++ b/examples/upsert/models/models.gen.go
@@ -20,6 +20,8 @@ type PGClient struct {
 	impl       pgClientImpl
 	topLevelDB pggen.DBConn
 
+	errorConverter func(error) error
+
 	// These column indexes are used at run time to enable us to 'SELECT *' against
 	// a table that has the same columns in a different order from the ones that we
 	// saw in the table we used to generate code. This means that you don't have to worry
@@ -38,6 +40,12 @@ var _ = sync.RWMutex{}
 // If you provide your own wrapper around a '*sql.DB' for logging or
 // custom tracing, you MUST forward all calls to an underlying '*sql.DB'
 // member of your wrapper.
+//
+// If the DBConn passed into NewPGClient implements an ErrorConverter
+// method which returns a func(error) error, the result of calling the
+// ErrorConverter method will be called on every error that the generated
+// code returns right before the error is returned. If ErrorConverter
+// returns nil or is not present, it will default to the identity function.
 func NewPGClient(conn pggen.DBConn) *PGClient {
 	client := PGClient{
 		topLevelDB: conn,
@@ -45,6 +53,17 @@ func NewPGClient(conn pggen.DBConn) *PGClient {
 	client.impl = pgClientImpl{
 		db:     conn,
 		client: &client,
+	}
+
+	// extract the optional error converter routine
+	ec, ok := conn.(interface {
+		ErrorConverter() func(error) error
+	})
+	if ok {
+		client.errorConverter = ec.ErrorConverter()
+	}
+	if client.errorConverter == nil {
+		client.errorConverter = func(err error) error { return err }
 	}
 
 	return &client
@@ -57,7 +76,7 @@ func (p *PGClient) Handle() pggen.DBHandle {
 func (p *PGClient) BeginTx(ctx context.Context, opts *sql.TxOptions) (*TxPGClient, error) {
 	tx, err := p.topLevelDB.BeginTx(ctx, opts)
 	if err != nil {
-		return nil, err
+		return nil, p.errorConverter(err)
 	}
 
 	return &TxPGClient{
@@ -71,7 +90,7 @@ func (p *PGClient) BeginTx(ctx context.Context, opts *sql.TxOptions) (*TxPGClien
 func (p *PGClient) Conn(ctx context.Context) (*ConnPGClient, error) {
 	conn, err := p.topLevelDB.Conn(ctx)
 	if err != nil {
-		return nil, err
+		return nil, p.errorConverter(err)
 	}
 
 	return &ConnPGClient{impl: pgClientImpl{db: conn, client: p}}, nil
@@ -187,18 +206,19 @@ func (p *pgClientImpl) listUser(
 		pgtypes.Array(ids),
 	)
 	if err != nil {
-		return nil, err
+		return nil, p.client.errorConverter(err)
 	}
 	defer func() {
 		if err == nil {
 			err = rows.Close()
 			if err != nil {
 				ret = nil
+				err = p.client.errorConverter(err)
 			}
 		} else {
 			rowErr := rows.Close()
 			if rowErr != nil {
-				err = fmt.Errorf("%s AND %s", err.Error(), rowErr.Error())
+				err = p.client.errorConverter(fmt.Errorf("%s AND %s", err.Error(), rowErr.Error()))
 			}
 		}
 	}()
@@ -208,24 +228,24 @@ func (p *pgClientImpl) listUser(
 		var value User
 		err = value.Scan(ctx, p.client, rows)
 		if err != nil {
-			return nil, err
+			return nil, p.client.errorConverter(err)
 		}
 		ret = append(ret, value)
 	}
 
 	if len(ret) != len(ids) {
 		if isGet {
-			return nil, &unstable.NotFoundError{
+			return nil, p.client.errorConverter(&unstable.NotFoundError{
 				Msg: "GetUser: record not found",
-			}
+			})
 		} else {
-			return nil, &unstable.NotFoundError{
+			return nil, p.client.errorConverter(&unstable.NotFoundError{
 				Msg: fmt.Sprintf(
 					"ListUser: asked for %d records, found %d",
 					len(ids),
 					len(ret),
 				),
-			}
+			})
 		}
 	}
 
@@ -272,12 +292,11 @@ func (p *pgClientImpl) insertUser(
 	var ids []int64
 	ids, err = p.bulkInsertUser(ctx, []User{*value}, opts...)
 	if err != nil {
-		return
+		return ret, p.client.errorConverter(err)
 	}
 
 	if len(ids) != 1 {
-		err = fmt.Errorf("inserting a User: %d ids (expected 1)", len(ids))
-		return
+		return ret, p.client.errorConverter(fmt.Errorf("inserting a User: %d ids (expected 1)", len(ids)))
 	}
 
 	ret = ids[0]
@@ -358,7 +377,7 @@ func (p *pgClientImpl) bulkInsertUser(
 
 	rows, err := p.queryContext(ctx, bulkInsertQuery, args...)
 	if err != nil {
-		return nil, err
+		return nil, p.client.errorConverter(err)
 	}
 	defer rows.Close()
 
@@ -367,7 +386,7 @@ func (p *pgClientImpl) bulkInsertUser(
 		var id int64
 		err = rows.Scan(&(id))
 		if err != nil {
-			return nil, err
+			return nil, p.client.errorConverter(err)
 		}
 		ids = append(ids, id)
 	}
@@ -449,8 +468,7 @@ func (p *pgClientImpl) updateUser(
 	opts ...pggen.UpdateOpt,
 ) (ret int64, err error) {
 	if !fieldMask.Test(UserIdFieldIndex) {
-		err = fmt.Errorf(`primary key required for updates to 'users'`)
-		return
+		return ret, p.client.errorConverter(fmt.Errorf(`primary key required for updates to 'users'`))
 	}
 
 	updateStmt := genUpdateStmt(
@@ -482,7 +500,7 @@ func (p *pgClientImpl) updateUser(
 	err = p.db.QueryRowContext(ctx, updateStmt, args...).
 		Scan(&(id))
 	if err != nil {
-		return
+		return ret, p.client.errorConverter(err)
 	}
 
 	return id, nil
@@ -700,7 +718,7 @@ func (p *pgClientImpl) bulkUpsertUser(
 
 	rows, err := p.queryContext(ctx, stmt.String(), args...)
 	if err != nil {
-		return nil, err
+		return nil, p.client.errorConverter(err)
 	}
 	defer rows.Close()
 
@@ -709,7 +727,7 @@ func (p *pgClientImpl) bulkUpsertUser(
 		var id int64
 		err = rows.Scan(&(id))
 		if err != nil {
-			return nil, err
+			return nil, p.client.errorConverter(err)
 		}
 		ids = append(ids, id)
 	}
@@ -779,20 +797,20 @@ func (p *pgClientImpl) bulkDeleteUser(
 		pgtypes.Array(ids),
 	)
 	if err != nil {
-		return err
+		return p.client.errorConverter(err)
 	}
 
 	nrows, err := res.RowsAffected()
 	if err != nil {
-		return err
+		return p.client.errorConverter(err)
 	}
 
 	if nrows != int64(len(ids)) {
-		return fmt.Errorf(
+		return p.client.errorConverter(fmt.Errorf(
 			"BulkDeleteUser: %d rows deleted, expected %d",
 			nrows,
 			len(ids),
-		)
+		))
 	}
 
 	return err
@@ -869,10 +887,10 @@ func (p *pgClientImpl) implUserBulkFillIncludes(
 	loadedRecordTab map[string]interface{},
 ) (err error) {
 	if includes.TableName != `users` {
-		return fmt.Errorf(
+		return p.client.errorConverter(fmt.Errorf(
 			`expected includes for 'users', got '%s'`,
 			includes.TableName,
-		)
+		))
 	}
 
 	loadedTab, inMap := loadedRecordTab[`users`]

--- a/examples/uuid/models/models.gen.go
+++ b/examples/uuid/models/models.gen.go
@@ -21,6 +21,8 @@ type PGClient struct {
 	impl       pgClientImpl
 	topLevelDB pggen.DBConn
 
+	errorConverter func(error) error
+
 	// These column indexes are used at run time to enable us to 'SELECT *' against
 	// a table that has the same columns in a different order from the ones that we
 	// saw in the table we used to generate code. This means that you don't have to worry
@@ -39,6 +41,12 @@ var _ = sync.RWMutex{}
 // If you provide your own wrapper around a '*sql.DB' for logging or
 // custom tracing, you MUST forward all calls to an underlying '*sql.DB'
 // member of your wrapper.
+//
+// If the DBConn passed into NewPGClient implements an ErrorConverter
+// method which returns a func(error) error, the result of calling the
+// ErrorConverter method will be called on every error that the generated
+// code returns right before the error is returned. If ErrorConverter
+// returns nil or is not present, it will default to the identity function.
 func NewPGClient(conn pggen.DBConn) *PGClient {
 	client := PGClient{
 		topLevelDB: conn,
@@ -46,6 +54,17 @@ func NewPGClient(conn pggen.DBConn) *PGClient {
 	client.impl = pgClientImpl{
 		db:     conn,
 		client: &client,
+	}
+
+	// extract the optional error converter routine
+	ec, ok := conn.(interface {
+		ErrorConverter() func(error) error
+	})
+	if ok {
+		client.errorConverter = ec.ErrorConverter()
+	}
+	if client.errorConverter == nil {
+		client.errorConverter = func(err error) error { return err }
 	}
 
 	return &client
@@ -58,7 +77,7 @@ func (p *PGClient) Handle() pggen.DBHandle {
 func (p *PGClient) BeginTx(ctx context.Context, opts *sql.TxOptions) (*TxPGClient, error) {
 	tx, err := p.topLevelDB.BeginTx(ctx, opts)
 	if err != nil {
-		return nil, err
+		return nil, p.errorConverter(err)
 	}
 
 	return &TxPGClient{
@@ -72,7 +91,7 @@ func (p *PGClient) BeginTx(ctx context.Context, opts *sql.TxOptions) (*TxPGClien
 func (p *PGClient) Conn(ctx context.Context) (*ConnPGClient, error) {
 	conn, err := p.topLevelDB.Conn(ctx)
 	if err != nil {
-		return nil, err
+		return nil, p.errorConverter(err)
 	}
 
 	return &ConnPGClient{impl: pgClientImpl{db: conn, client: p}}, nil
@@ -188,18 +207,19 @@ func (p *pgClientImpl) listUser(
 		pgtypes.Array(ids),
 	)
 	if err != nil {
-		return nil, err
+		return nil, p.client.errorConverter(err)
 	}
 	defer func() {
 		if err == nil {
 			err = rows.Close()
 			if err != nil {
 				ret = nil
+				err = p.client.errorConverter(err)
 			}
 		} else {
 			rowErr := rows.Close()
 			if rowErr != nil {
-				err = fmt.Errorf("%s AND %s", err.Error(), rowErr.Error())
+				err = p.client.errorConverter(fmt.Errorf("%s AND %s", err.Error(), rowErr.Error()))
 			}
 		}
 	}()
@@ -209,24 +229,24 @@ func (p *pgClientImpl) listUser(
 		var value User
 		err = value.Scan(ctx, p.client, rows)
 		if err != nil {
-			return nil, err
+			return nil, p.client.errorConverter(err)
 		}
 		ret = append(ret, value)
 	}
 
 	if len(ret) != len(ids) {
 		if isGet {
-			return nil, &unstable.NotFoundError{
+			return nil, p.client.errorConverter(&unstable.NotFoundError{
 				Msg: "GetUser: record not found",
-			}
+			})
 		} else {
-			return nil, &unstable.NotFoundError{
+			return nil, p.client.errorConverter(&unstable.NotFoundError{
 				Msg: fmt.Sprintf(
 					"ListUser: asked for %d records, found %d",
 					len(ids),
 					len(ret),
 				),
-			}
+			})
 		}
 	}
 
@@ -273,12 +293,11 @@ func (p *pgClientImpl) insertUser(
 	var ids []int64
 	ids, err = p.bulkInsertUser(ctx, []User{*value}, opts...)
 	if err != nil {
-		return
+		return ret, p.client.errorConverter(err)
 	}
 
 	if len(ids) != 1 {
-		err = fmt.Errorf("inserting a User: %d ids (expected 1)", len(ids))
-		return
+		return ret, p.client.errorConverter(fmt.Errorf("inserting a User: %d ids (expected 1)", len(ids)))
 	}
 
 	ret = ids[0]
@@ -356,7 +375,7 @@ func (p *pgClientImpl) bulkInsertUser(
 
 	rows, err := p.queryContext(ctx, bulkInsertQuery, args...)
 	if err != nil {
-		return nil, err
+		return nil, p.client.errorConverter(err)
 	}
 	defer rows.Close()
 
@@ -365,7 +384,7 @@ func (p *pgClientImpl) bulkInsertUser(
 		var id int64
 		err = rows.Scan(&(id))
 		if err != nil {
-			return nil, err
+			return nil, p.client.errorConverter(err)
 		}
 		ids = append(ids, id)
 	}
@@ -445,8 +464,7 @@ func (p *pgClientImpl) updateUser(
 	opts ...pggen.UpdateOpt,
 ) (ret int64, err error) {
 	if !fieldMask.Test(UserIdFieldIndex) {
-		err = fmt.Errorf(`primary key required for updates to 'users'`)
-		return
+		return ret, p.client.errorConverter(fmt.Errorf(`primary key required for updates to 'users'`))
 	}
 
 	updateStmt := genUpdateStmt(
@@ -475,7 +493,7 @@ func (p *pgClientImpl) updateUser(
 	err = p.db.QueryRowContext(ctx, updateStmt, args...).
 		Scan(&(id))
 	if err != nil {
-		return
+		return ret, p.client.errorConverter(err)
 	}
 
 	return id, nil
@@ -686,7 +704,7 @@ func (p *pgClientImpl) bulkUpsertUser(
 
 	rows, err := p.queryContext(ctx, stmt.String(), args...)
 	if err != nil {
-		return nil, err
+		return nil, p.client.errorConverter(err)
 	}
 	defer rows.Close()
 
@@ -695,7 +713,7 @@ func (p *pgClientImpl) bulkUpsertUser(
 		var id int64
 		err = rows.Scan(&(id))
 		if err != nil {
-			return nil, err
+			return nil, p.client.errorConverter(err)
 		}
 		ids = append(ids, id)
 	}
@@ -765,20 +783,20 @@ func (p *pgClientImpl) bulkDeleteUser(
 		pgtypes.Array(ids),
 	)
 	if err != nil {
-		return err
+		return p.client.errorConverter(err)
 	}
 
 	nrows, err := res.RowsAffected()
 	if err != nil {
-		return err
+		return p.client.errorConverter(err)
 	}
 
 	if nrows != int64(len(ids)) {
-		return fmt.Errorf(
+		return p.client.errorConverter(fmt.Errorf(
 			"BulkDeleteUser: %d rows deleted, expected %d",
 			nrows,
 			len(ids),
-		)
+		))
 	}
 
 	return err
@@ -855,10 +873,10 @@ func (p *pgClientImpl) implUserBulkFillIncludes(
 	loadedRecordTab map[string]interface{},
 ) (err error) {
 	if includes.TableName != `users` {
-		return fmt.Errorf(
+		return p.client.errorConverter(fmt.Errorf(
 			`expected includes for 'users', got '%s'`,
 			includes.TableName,
-		)
+		))
 	}
 
 	loadedTab, inMap := loadedRecordTab[`users`]

--- a/gen/gen_query.go
+++ b/gen/gen_query.go
@@ -221,24 +221,25 @@ func (p *pgClientImpl) {{ .ConfigData.Name }}(
 		{{- end }}
 	)
 	if err != nil {
-		return zero, err
+		return zero, p.client.errorConverter(err)
 	}
 	defer func() {
 		if err == nil {
 			err = rows.Close()
 			if err != nil {
 				ret = zero
+				err = p.client.errorConverter(err)
 			}
 		} else {
 			rowErr := rows.Close()
 			if rowErr != nil {
-				err = fmt.Errorf("%s AND %s", err.Error(), rowErr.Error())
+				err = p.client.errorConverter(fmt.Errorf("%s AND %s", err.Error(), rowErr.Error()))
 			}
 		}
 	}()
 
 	if !rows.Next() {
-		return zero, &unstable.NotFoundError{ Msg: "{{ .ConfigData.Name }}: no results" }
+		return zero, p.client.errorConverter(&unstable.NotFoundError{ Msg: "{{ .ConfigData.Name }}: no results" })
 	}
 
 	{{- if .MultiReturn }}
@@ -249,13 +250,13 @@ func (p *pgClientImpl) {{ .ConfigData.Name }}(
 	var scanTgt {{ (index .ReturnCols 0).TypeInfo.ScanNullName }}
 	err = rows.Scan({{ call (index .ReturnCols 0).TypeInfo.NullSqlReceiver "scanTgt" }})
 	if err != nil {
-		return zero, err
+		return zero, p.client.errorConverter(err)
 	}
 	ret = {{ call (index .ReturnCols 0).TypeInfo.NullConvertFunc "scanTgt" }}
 	{{- else }}
 	err = rows.Scan({{ call (index .ReturnCols 0).TypeInfo.SqlReceiver "ret" }})
 	if err != nil {
-		return zero, err
+		return zero, p.client.errorConverter(err)
 	}
 	{{- end }}
 	{{- end }}
@@ -337,18 +338,19 @@ func (p *pgClientImpl) {{ .ConfigData.Name }}(
 		{{- end}}
 	)
 	if err != nil {
-		return nil, err
+		return nil, p.client.errorConverter(err)
 	}
 	defer func() {
 		if err == nil {
 			err = rows.Close()
 			if err != nil {
 				ret = nil
+				err = p.client.errorConverter(err)
 			}
 		} else {
 			rowErr := rows.Close()
 			if rowErr != nil {
-				err = fmt.Errorf("%s AND %s", err.Error(), rowErr.Error())
+				err = p.client.errorConverter(fmt.Errorf("%s AND %s", err.Error(), rowErr.Error()))
 			}
 		}
 	}()
@@ -362,13 +364,13 @@ func (p *pgClientImpl) {{ .ConfigData.Name }}(
 		var scanTgt {{ (index .ReturnCols 0).TypeInfo.ScanNullName }}
 		err = rows.Scan({{ call (index .ReturnCols 0).TypeInfo.NullSqlReceiver "scanTgt" }})
 		if err != nil {
-			return nil, err
+			return nil, p.client.errorConverter(err)
 		}
 		row = {{ call (index .ReturnCols 0).TypeInfo.NullConvertFunc "scanTgt" }}
 		{{- else }}
 		err = rows.Scan({{ call (index .ReturnCols 0).TypeInfo.SqlReceiver "row" }})
 		if err != nil {
-			return nil, err
+			return nil, p.client.errorConverter(err)
 		}
 		{{- end }}
 		{{- end }}

--- a/gen/gen_stmt.go
+++ b/gen/gen_stmt.go
@@ -89,7 +89,7 @@ func (p *pgClientImpl) {{ .ConfigData.Name }}(
 	{{ .GoName }} {{ .TypeInfo.Name }},
 	{{- end}}
 ) (sql.Result, error) {
-	return p.db.ExecContext(
+	res, err := p.db.ExecContext(
 		ctx,
 		` + "`" +
 	`{{ .ConfigData.Body }}` +
@@ -98,6 +98,7 @@ func (p *pgClientImpl) {{ .ConfigData.Name }}(
 		{{ call .TypeInfo.SqlArgument .GoName }},
 		{{- end }}
 	)
+	return res, p.client.errorConverter(err)
 }
 
 `))

--- a/middleware/middleware.go
+++ b/middleware/middleware.go
@@ -1,8 +1,19 @@
 // (c) 2021 Opendoor Labs Inc.
 // This code is licenced under the MIT licence (see the LICENCE file in the repo root).
-// The middleware package is used in pggen to add middleware to be executed
-// surrounding the DB calls execution. The intent is to have the ability to add cutom
-// logging, metrics, tracing, side effects ...
+//
+// Package middleware is used in pggen to add middleware to be executed
+// surrounding the DB calls execution. The intent is to have the ability to add custom
+// logging, metrics, tracing, side effects.
+//
+// The DBConnWrapper struct is the main character of this package. It wraps a database
+// connection, and implements the database connection interface itself. The thing it
+// brings to the table is making it easy to inject your own interceptor routines for
+// commen SQL operations.
+//
+// In addition to allowing you to hook SQL operations, you can attach an ErrorConverter
+// routine to the DBConnWrapper. This routine will be called by the generated code before
+// any error is returned. This allows you to conveniantly translate pggen errors into the
+// error format used in the rest of your application.
 package middleware
 
 import (
@@ -30,10 +41,11 @@ type BeginTxMiddleware func(BeginTxFunc) BeginTxFunc
 type DBConnWrapper struct {
 	dbConn pggen.DBConn
 
-	execFunc     ExecFunc
-	queryFunc    QueryFunc
-	queryRowFunc QueryRowFunc
-	beginTxFunc  BeginTxFunc
+	execFunc           ExecFunc
+	queryFunc          QueryFunc
+	queryRowFunc       QueryRowFunc
+	beginTxFunc        BeginTxFunc
+	errorConverterFunc func(error) error
 }
 
 // NewDBConnWrapper wraps the DBConn in struct to which middlewares can be added
@@ -54,7 +66,7 @@ func (w *DBConnWrapper) WithExecMiddleware(execMiddleware ExecMiddleware) *DBCon
 	return w
 }
 
-// ExecContext apply the middleware if any and execute ExecContext on the wrapped DBConn
+// ExecContext applies the middleware if any and executes ExecContext on the wrapped DBConn
 func (w *DBConnWrapper) ExecContext(ctx context.Context, stmt string, args ...interface{}) (sql.Result, error) {
 	return w.execFunc(ctx, stmt, args...)
 }
@@ -65,6 +77,7 @@ func (w *DBConnWrapper) WithQueryMiddleware(queryMiddleware QueryMiddleware) *DB
 	return w
 }
 
+// QueryContext applies the middleware if any and executes QueryContext on the wrapped DBConn
 func (w *DBConnWrapper) QueryContext(ctx context.Context, query string, args ...interface{}) (*sql.Rows, error) {
 	return w.queryFunc(ctx, query, args...)
 }
@@ -75,17 +88,33 @@ func (w *DBConnWrapper) WithQueryRowMiddleware(queryRowMiddleware QueryRowMiddle
 	return w
 }
 
+// QueryRowContext applies the middleware if any and executes QueryRowContext on the wrapped DBConn
 func (w *DBConnWrapper) QueryRowContext(ctx context.Context, query string, args ...interface{}) *sql.Row {
 	return w.queryRowFunc(ctx, query, args...)
 }
 
+// WithWithBeginTxMiddleware adds the middleware for the BeginTx to the DBConnWrapper
 func (w *DBConnWrapper) WithBeginTxMiddleware(beginTxMiddleware BeginTxMiddleware) *DBConnWrapper {
 	w.beginTxFunc = beginTxMiddleware(w.beginTxFunc)
 	return w
 }
 
+// BeginTx applies the middleware if any and executes BeginTx on the wrapped DBConn
 func (w *DBConnWrapper) BeginTx(ctx context.Context, opts *sql.TxOptions) (*sql.Tx, error) {
 	return w.beginTxFunc(ctx, opts)
+}
+
+// WithErrorConverter adds an error converter function. A builder method.
+func (w *DBConnWrapper) WithErrorConverter(errorConverter func(error) error) *DBConnWrapper {
+	w.errorConverterFunc = errorConverter
+	return w
+}
+
+// ErrorConverter returns a function to be applied to all error values before they are
+// returned from the generated client. It is meant to be called by the generated NewPGClient
+// routine, and probably doesn't ever need to be called from user code.
+func (w *DBConnWrapper) ErrorConverter() func(error) error {
+	return w.errorConverterFunc
 }
 
 // Unchanged


### PR DESCRIPTION
This patch adds support for injecting a routine for
converting pggen errors to errors of a different sort.
It is already possible to intercept errors systemically
at the level of interactions with the database driver,
but pggen itself creates a few errors that cannot be
intercepted in this way (including the NotFoundError,
which is probably the most interesting sort of error
that pggen returns).