### PR TITLE
Add disable timestamps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 *.test
 main
+
+# IntelliJ
+.idea/
+*.iml

--- a/cmd/pggen/test/conn_test.go
+++ b/cmd/pggen/test/conn_test.go
@@ -1,8 +1,9 @@
 package test
 
 import (
-	"github.com/opendoor/pggen/cmd/pggen/test/models"
 	"testing"
+
+	"github.com/opendoor/pggen/cmd/pggen/test/models"
 )
 
 func TestConnSmoke(t *testing.T) {

--- a/cmd/pggen/test/test.go
+++ b/cmd/pggen/test/test.go
@@ -4,13 +4,14 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
-	_ "github.com/jackc/pgx/v4/stdlib" // load driver
-	_ "github.com/lib/pq"              // load driver (we still test against lib/pq)
 	"log"
 	"os"
 	"os/exec"
 	"regexp"
 	"testing"
+
+	_ "github.com/jackc/pgx/v4/stdlib" // load driver
+	_ "github.com/lib/pq"              // load driver (we still test against lib/pq)
 
 	"github.com/opendoor/pggen/cmd/pggen/test/models"
 	ensureSchema "github.com/opendoor/pggen/tools/ensure-schema/lib"

--- a/cmd/pggen/test/timestamps_test.go
+++ b/cmd/pggen/test/timestamps_test.go
@@ -81,7 +81,7 @@ func TestDisableTimestamps(t *testing.T) {
 	date := time.Date(2020, 1, 23, 15, 1, 11, 0, time.UTC)
 	blah := "blah"
 	id, err := txClient.InsertTimestampsBoth(ctx, &models.TimestampsBoth{
-		Payload: &blah,
+		Payload:   &blah,
 		CreatedAt: &date,
 		UpdatedAt: date,
 	}, pggen.InsertDisableTimestamps)
@@ -103,7 +103,7 @@ func TestDisableTimestamps(t *testing.T) {
 	mask.Set(models.TimestampsBothPayloadFieldIndex, true)
 	newPayload := "blah blah"
 	model := &models.TimestampsBoth{
-		Id: id,
+		Id:      id,
 		Payload: &newPayload,
 	}
 	id, err = txClient.UpdateTimestampsBoth(ctx, model, mask, pggen.UpdateDisableTimestamps)

--- a/examples/extending_models/models/models.gen.go
+++ b/examples/extending_models/models/models.gen.go
@@ -432,7 +432,7 @@ func (p *PGClient) UpdateDog(
 	fieldMask pggen.FieldSet,
 	opts ...pggen.UpdateOpt,
 ) (ret int64, err error) {
-	return p.impl.updateDog(ctx, value, fieldMask)
+	return p.impl.updateDog(ctx, value, fieldMask, opts...)
 }
 
 // Update a Dog. 'value' must at the least have
@@ -446,7 +446,7 @@ func (tx *TxPGClient) UpdateDog(
 	fieldMask pggen.FieldSet,
 	opts ...pggen.UpdateOpt,
 ) (ret int64, err error) {
-	return tx.impl.updateDog(ctx, value, fieldMask)
+	return tx.impl.updateDog(ctx, value, fieldMask, opts...)
 }
 
 // Update a Dog. 'value' must at the least have
@@ -460,7 +460,7 @@ func (conn *ConnPGClient) UpdateDog(
 	fieldMask pggen.FieldSet,
 	opts ...pggen.UpdateOpt,
 ) (ret int64, err error) {
-	return conn.impl.updateDog(ctx, value, fieldMask)
+	return conn.impl.updateDog(ctx, value, fieldMask, opts...)
 }
 func (p *pgClientImpl) updateDog(
 	ctx context.Context,
@@ -468,6 +468,12 @@ func (p *pgClientImpl) updateDog(
 	fieldMask pggen.FieldSet,
 	opts ...pggen.UpdateOpt,
 ) (ret int64, err error) {
+
+	opt := pggen.UpdateOptions{}
+	for _, o := range opts {
+		o(&opt)
+	}
+
 	if !fieldMask.Test(DogIdFieldIndex) {
 		return ret, p.client.errorConverter(fmt.Errorf(`primary key required for updates to 'dogs'`))
 	}

--- a/examples/extending_models/models/models.gen.go
+++ b/examples/extending_models/models/models.gen.go
@@ -7,12 +7,13 @@ import (
 	"database/sql"
 	"database/sql/driver"
 	"fmt"
+	"strings"
+	"sync"
+
 	"github.com/ethanpailes/pgtypes"
 	"github.com/opendoor/pggen"
 	"github.com/opendoor/pggen/include"
 	"github.com/opendoor/pggen/unstable"
-	"strings"
-	"sync"
 )
 
 // PGClient wraps either a 'sql.DB' or a 'sql.Tx'. All pggen-generated

--- a/examples/extending_models/models/pggen_prelude.gen.go
+++ b/examples/extending_models/models/pggen_prelude.gen.go
@@ -7,10 +7,11 @@ import (
 	"database/sql"
 	"database/sql/driver"
 	"fmt"
-	"github.com/jackc/pgconn"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/jackc/pgconn"
 
 	"github.com/opendoor/pggen"
 )

--- a/examples/id_in_set/models/models.gen.go
+++ b/examples/id_in_set/models/models.gen.go
@@ -6,12 +6,13 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"strings"
+	"sync"
+
 	"github.com/ethanpailes/pgtypes"
 	"github.com/opendoor/pggen"
 	"github.com/opendoor/pggen/include"
 	"github.com/opendoor/pggen/unstable"
-	"strings"
-	"sync"
 )
 
 // PGClient wraps either a 'sql.DB' or a 'sql.Tx'. All pggen-generated

--- a/examples/id_in_set/models/models.gen.go
+++ b/examples/id_in_set/models/models.gen.go
@@ -423,7 +423,7 @@ func (p *PGClient) UpdateFoo(
 	fieldMask pggen.FieldSet,
 	opts ...pggen.UpdateOpt,
 ) (ret int64, err error) {
-	return p.impl.updateFoo(ctx, value, fieldMask)
+	return p.impl.updateFoo(ctx, value, fieldMask, opts...)
 }
 
 // Update a Foo. 'value' must at the least have
@@ -437,7 +437,7 @@ func (tx *TxPGClient) UpdateFoo(
 	fieldMask pggen.FieldSet,
 	opts ...pggen.UpdateOpt,
 ) (ret int64, err error) {
-	return tx.impl.updateFoo(ctx, value, fieldMask)
+	return tx.impl.updateFoo(ctx, value, fieldMask, opts...)
 }
 
 // Update a Foo. 'value' must at the least have
@@ -451,7 +451,7 @@ func (conn *ConnPGClient) UpdateFoo(
 	fieldMask pggen.FieldSet,
 	opts ...pggen.UpdateOpt,
 ) (ret int64, err error) {
-	return conn.impl.updateFoo(ctx, value, fieldMask)
+	return conn.impl.updateFoo(ctx, value, fieldMask, opts...)
 }
 func (p *pgClientImpl) updateFoo(
 	ctx context.Context,
@@ -459,6 +459,12 @@ func (p *pgClientImpl) updateFoo(
 	fieldMask pggen.FieldSet,
 	opts ...pggen.UpdateOpt,
 ) (ret int64, err error) {
+
+	opt := pggen.UpdateOptions{}
+	for _, o := range opts {
+		o(&opt)
+	}
+
 	if !fieldMask.Test(FooIdFieldIndex) {
 		return ret, p.client.errorConverter(fmt.Errorf(`primary key required for updates to 'foos'`))
 	}

--- a/examples/id_in_set/models/pggen_prelude.gen.go
+++ b/examples/id_in_set/models/pggen_prelude.gen.go
@@ -7,10 +7,11 @@ import (
 	"database/sql"
 	"database/sql/driver"
 	"fmt"
-	"github.com/jackc/pgconn"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/jackc/pgconn"
 
 	"github.com/opendoor/pggen"
 )

--- a/examples/include_specs/models/models.gen.go
+++ b/examples/include_specs/models/models.gen.go
@@ -6,12 +6,13 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"strings"
+	"sync"
+
 	"github.com/ethanpailes/pgtypes"
 	"github.com/opendoor/pggen"
 	"github.com/opendoor/pggen/include"
 	"github.com/opendoor/pggen/unstable"
-	"strings"
-	"sync"
 )
 
 // PGClient wraps either a 'sql.DB' or a 'sql.Tx'. All pggen-generated

--- a/examples/include_specs/models/models.gen.go
+++ b/examples/include_specs/models/models.gen.go
@@ -430,7 +430,7 @@ func (p *PGClient) UpdateGrandparent(
 	fieldMask pggen.FieldSet,
 	opts ...pggen.UpdateOpt,
 ) (ret int64, err error) {
-	return p.impl.updateGrandparent(ctx, value, fieldMask)
+	return p.impl.updateGrandparent(ctx, value, fieldMask, opts...)
 }
 
 // Update a Grandparent. 'value' must at the least have
@@ -444,7 +444,7 @@ func (tx *TxPGClient) UpdateGrandparent(
 	fieldMask pggen.FieldSet,
 	opts ...pggen.UpdateOpt,
 ) (ret int64, err error) {
-	return tx.impl.updateGrandparent(ctx, value, fieldMask)
+	return tx.impl.updateGrandparent(ctx, value, fieldMask, opts...)
 }
 
 // Update a Grandparent. 'value' must at the least have
@@ -458,7 +458,7 @@ func (conn *ConnPGClient) UpdateGrandparent(
 	fieldMask pggen.FieldSet,
 	opts ...pggen.UpdateOpt,
 ) (ret int64, err error) {
-	return conn.impl.updateGrandparent(ctx, value, fieldMask)
+	return conn.impl.updateGrandparent(ctx, value, fieldMask, opts...)
 }
 func (p *pgClientImpl) updateGrandparent(
 	ctx context.Context,
@@ -466,6 +466,12 @@ func (p *pgClientImpl) updateGrandparent(
 	fieldMask pggen.FieldSet,
 	opts ...pggen.UpdateOpt,
 ) (ret int64, err error) {
+
+	opt := pggen.UpdateOptions{}
+	for _, o := range opts {
+		o(&opt)
+	}
+
 	if !fieldMask.Test(GrandparentIdFieldIndex) {
 		return ret, p.client.errorConverter(fmt.Errorf(`primary key required for updates to 'grandparents'`))
 	}
@@ -1389,7 +1395,7 @@ func (p *PGClient) UpdateParent(
 	fieldMask pggen.FieldSet,
 	opts ...pggen.UpdateOpt,
 ) (ret int64, err error) {
-	return p.impl.updateParent(ctx, value, fieldMask)
+	return p.impl.updateParent(ctx, value, fieldMask, opts...)
 }
 
 // Update a Parent. 'value' must at the least have
@@ -1403,7 +1409,7 @@ func (tx *TxPGClient) UpdateParent(
 	fieldMask pggen.FieldSet,
 	opts ...pggen.UpdateOpt,
 ) (ret int64, err error) {
-	return tx.impl.updateParent(ctx, value, fieldMask)
+	return tx.impl.updateParent(ctx, value, fieldMask, opts...)
 }
 
 // Update a Parent. 'value' must at the least have
@@ -1417,7 +1423,7 @@ func (conn *ConnPGClient) UpdateParent(
 	fieldMask pggen.FieldSet,
 	opts ...pggen.UpdateOpt,
 ) (ret int64, err error) {
-	return conn.impl.updateParent(ctx, value, fieldMask)
+	return conn.impl.updateParent(ctx, value, fieldMask, opts...)
 }
 func (p *pgClientImpl) updateParent(
 	ctx context.Context,
@@ -1425,6 +1431,12 @@ func (p *pgClientImpl) updateParent(
 	fieldMask pggen.FieldSet,
 	opts ...pggen.UpdateOpt,
 ) (ret int64, err error) {
+
+	opt := pggen.UpdateOptions{}
+	for _, o := range opts {
+		o(&opt)
+	}
+
 	if !fieldMask.Test(ParentIdFieldIndex) {
 		return ret, p.client.errorConverter(fmt.Errorf(`primary key required for updates to 'parents'`))
 	}
@@ -2342,7 +2354,7 @@ func (p *PGClient) UpdateChild(
 	fieldMask pggen.FieldSet,
 	opts ...pggen.UpdateOpt,
 ) (ret int64, err error) {
-	return p.impl.updateChild(ctx, value, fieldMask)
+	return p.impl.updateChild(ctx, value, fieldMask, opts...)
 }
 
 // Update a Child. 'value' must at the least have
@@ -2356,7 +2368,7 @@ func (tx *TxPGClient) UpdateChild(
 	fieldMask pggen.FieldSet,
 	opts ...pggen.UpdateOpt,
 ) (ret int64, err error) {
-	return tx.impl.updateChild(ctx, value, fieldMask)
+	return tx.impl.updateChild(ctx, value, fieldMask, opts...)
 }
 
 // Update a Child. 'value' must at the least have
@@ -2370,7 +2382,7 @@ func (conn *ConnPGClient) UpdateChild(
 	fieldMask pggen.FieldSet,
 	opts ...pggen.UpdateOpt,
 ) (ret int64, err error) {
-	return conn.impl.updateChild(ctx, value, fieldMask)
+	return conn.impl.updateChild(ctx, value, fieldMask, opts...)
 }
 func (p *pgClientImpl) updateChild(
 	ctx context.Context,
@@ -2378,6 +2390,12 @@ func (p *pgClientImpl) updateChild(
 	fieldMask pggen.FieldSet,
 	opts ...pggen.UpdateOpt,
 ) (ret int64, err error) {
+
+	opt := pggen.UpdateOptions{}
+	for _, o := range opts {
+		o(&opt)
+	}
+
 	if !fieldMask.Test(ChildIdFieldIndex) {
 		return ret, p.client.errorConverter(fmt.Errorf(`primary key required for updates to 'children'`))
 	}

--- a/examples/include_specs/models/pggen_prelude.gen.go
+++ b/examples/include_specs/models/pggen_prelude.gen.go
@@ -7,10 +7,11 @@ import (
 	"database/sql"
 	"database/sql/driver"
 	"fmt"
-	"github.com/jackc/pgconn"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/jackc/pgconn"
 
 	"github.com/opendoor/pggen"
 )

--- a/examples/json_columns/models/models.gen.go
+++ b/examples/json_columns/models/models.gen.go
@@ -439,7 +439,7 @@ func (p *PGClient) UpdateUser(
 	fieldMask pggen.FieldSet,
 	opts ...pggen.UpdateOpt,
 ) (ret int64, err error) {
-	return p.impl.updateUser(ctx, value, fieldMask)
+	return p.impl.updateUser(ctx, value, fieldMask, opts...)
 }
 
 // Update a User. 'value' must at the least have
@@ -453,7 +453,7 @@ func (tx *TxPGClient) UpdateUser(
 	fieldMask pggen.FieldSet,
 	opts ...pggen.UpdateOpt,
 ) (ret int64, err error) {
-	return tx.impl.updateUser(ctx, value, fieldMask)
+	return tx.impl.updateUser(ctx, value, fieldMask, opts...)
 }
 
 // Update a User. 'value' must at the least have
@@ -467,7 +467,7 @@ func (conn *ConnPGClient) UpdateUser(
 	fieldMask pggen.FieldSet,
 	opts ...pggen.UpdateOpt,
 ) (ret int64, err error) {
-	return conn.impl.updateUser(ctx, value, fieldMask)
+	return conn.impl.updateUser(ctx, value, fieldMask, opts...)
 }
 func (p *pgClientImpl) updateUser(
 	ctx context.Context,
@@ -475,6 +475,12 @@ func (p *pgClientImpl) updateUser(
 	fieldMask pggen.FieldSet,
 	opts ...pggen.UpdateOpt,
 ) (ret int64, err error) {
+
+	opt := pggen.UpdateOptions{}
+	for _, o := range opts {
+		o(&opt)
+	}
+
 	if !fieldMask.Test(UserIdFieldIndex) {
 		return ret, p.client.errorConverter(fmt.Errorf(`primary key required for updates to 'users'`))
 	}

--- a/examples/json_columns/models/models.gen.go
+++ b/examples/json_columns/models/models.gen.go
@@ -8,13 +8,14 @@ import (
 	"database/sql/driver"
 	"encoding/json"
 	"fmt"
+	"strings"
+	"sync"
+
 	"github.com/ethanpailes/pgtypes"
 	"github.com/opendoor/pggen"
 	"github.com/opendoor/pggen/examples/json_columns/config"
 	"github.com/opendoor/pggen/include"
 	"github.com/opendoor/pggen/unstable"
-	"strings"
-	"sync"
 )
 
 // PGClient wraps either a 'sql.DB' or a 'sql.Tx'. All pggen-generated

--- a/examples/json_columns/models/pggen_prelude.gen.go
+++ b/examples/json_columns/models/pggen_prelude.gen.go
@@ -7,10 +7,11 @@ import (
 	"database/sql"
 	"database/sql/driver"
 	"fmt"
-	"github.com/jackc/pgconn"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/jackc/pgconn"
 
 	"github.com/opendoor/pggen"
 )

--- a/examples/middleware/models/models.gen.go
+++ b/examples/middleware/models/models.gen.go
@@ -6,12 +6,13 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"strings"
+	"sync"
+
 	"github.com/ethanpailes/pgtypes"
 	"github.com/opendoor/pggen"
 	"github.com/opendoor/pggen/include"
 	"github.com/opendoor/pggen/unstable"
-	"strings"
-	"sync"
 )
 
 // PGClient wraps either a 'sql.DB' or a 'sql.Tx'. All pggen-generated

--- a/examples/middleware/models/models.gen.go
+++ b/examples/middleware/models/models.gen.go
@@ -421,7 +421,7 @@ func (p *PGClient) UpdateFoo(
 	fieldMask pggen.FieldSet,
 	opts ...pggen.UpdateOpt,
 ) (ret int64, err error) {
-	return p.impl.updateFoo(ctx, value, fieldMask)
+	return p.impl.updateFoo(ctx, value, fieldMask, opts...)
 }
 
 // Update a Foo. 'value' must at the least have
@@ -435,7 +435,7 @@ func (tx *TxPGClient) UpdateFoo(
 	fieldMask pggen.FieldSet,
 	opts ...pggen.UpdateOpt,
 ) (ret int64, err error) {
-	return tx.impl.updateFoo(ctx, value, fieldMask)
+	return tx.impl.updateFoo(ctx, value, fieldMask, opts...)
 }
 
 // Update a Foo. 'value' must at the least have
@@ -449,7 +449,7 @@ func (conn *ConnPGClient) UpdateFoo(
 	fieldMask pggen.FieldSet,
 	opts ...pggen.UpdateOpt,
 ) (ret int64, err error) {
-	return conn.impl.updateFoo(ctx, value, fieldMask)
+	return conn.impl.updateFoo(ctx, value, fieldMask, opts...)
 }
 func (p *pgClientImpl) updateFoo(
 	ctx context.Context,
@@ -457,6 +457,12 @@ func (p *pgClientImpl) updateFoo(
 	fieldMask pggen.FieldSet,
 	opts ...pggen.UpdateOpt,
 ) (ret int64, err error) {
+
+	opt := pggen.UpdateOptions{}
+	for _, o := range opts {
+		o(&opt)
+	}
+
 	if !fieldMask.Test(FooIdFieldIndex) {
 		return ret, p.client.errorConverter(fmt.Errorf(`primary key required for updates to 'foos'`))
 	}

--- a/examples/middleware/models/pggen_prelude.gen.go
+++ b/examples/middleware/models/pggen_prelude.gen.go
@@ -7,10 +7,11 @@ import (
 	"database/sql"
 	"database/sql/driver"
 	"fmt"
-	"github.com/jackc/pgconn"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/jackc/pgconn"
 
 	"github.com/opendoor/pggen"
 )

--- a/examples/nullable_query_arguments/models/models.gen.go
+++ b/examples/nullable_query_arguments/models/models.gen.go
@@ -428,7 +428,7 @@ func (p *PGClient) UpdateUser(
 	fieldMask pggen.FieldSet,
 	opts ...pggen.UpdateOpt,
 ) (ret int64, err error) {
-	return p.impl.updateUser(ctx, value, fieldMask)
+	return p.impl.updateUser(ctx, value, fieldMask, opts...)
 }
 
 // Update a User. 'value' must at the least have
@@ -442,7 +442,7 @@ func (tx *TxPGClient) UpdateUser(
 	fieldMask pggen.FieldSet,
 	opts ...pggen.UpdateOpt,
 ) (ret int64, err error) {
-	return tx.impl.updateUser(ctx, value, fieldMask)
+	return tx.impl.updateUser(ctx, value, fieldMask, opts...)
 }
 
 // Update a User. 'value' must at the least have
@@ -456,7 +456,7 @@ func (conn *ConnPGClient) UpdateUser(
 	fieldMask pggen.FieldSet,
 	opts ...pggen.UpdateOpt,
 ) (ret int64, err error) {
-	return conn.impl.updateUser(ctx, value, fieldMask)
+	return conn.impl.updateUser(ctx, value, fieldMask, opts...)
 }
 func (p *pgClientImpl) updateUser(
 	ctx context.Context,
@@ -464,6 +464,12 @@ func (p *pgClientImpl) updateUser(
 	fieldMask pggen.FieldSet,
 	opts ...pggen.UpdateOpt,
 ) (ret int64, err error) {
+
+	opt := pggen.UpdateOptions{}
+	for _, o := range opts {
+		o(&opt)
+	}
+
 	if !fieldMask.Test(UserIdFieldIndex) {
 		return ret, p.client.errorConverter(fmt.Errorf(`primary key required for updates to 'users'`))
 	}

--- a/examples/nullable_query_arguments/models/models.gen.go
+++ b/examples/nullable_query_arguments/models/models.gen.go
@@ -6,12 +6,13 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"strings"
+	"sync"
+
 	"github.com/ethanpailes/pgtypes"
 	"github.com/opendoor/pggen"
 	"github.com/opendoor/pggen/include"
 	"github.com/opendoor/pggen/unstable"
-	"strings"
-	"sync"
 )
 
 // PGClient wraps either a 'sql.DB' or a 'sql.Tx'. All pggen-generated

--- a/examples/nullable_query_arguments/models/pggen_prelude.gen.go
+++ b/examples/nullable_query_arguments/models/pggen_prelude.gen.go
@@ -7,10 +7,11 @@ import (
 	"database/sql"
 	"database/sql/driver"
 	"fmt"
-	"github.com/jackc/pgconn"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/jackc/pgconn"
 
 	"github.com/opendoor/pggen"
 )

--- a/examples/query/models/models.gen.go
+++ b/examples/query/models/models.gen.go
@@ -6,12 +6,13 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"strings"
+	"sync"
+
 	"github.com/ethanpailes/pgtypes"
 	"github.com/opendoor/pggen"
 	"github.com/opendoor/pggen/include"
 	"github.com/opendoor/pggen/unstable"
-	"strings"
-	"sync"
 )
 
 // PGClient wraps either a 'sql.DB' or a 'sql.Tx'. All pggen-generated

--- a/examples/query/models/models.gen.go
+++ b/examples/query/models/models.gen.go
@@ -430,7 +430,7 @@ func (p *PGClient) UpdateUser(
 	fieldMask pggen.FieldSet,
 	opts ...pggen.UpdateOpt,
 ) (ret int64, err error) {
-	return p.impl.updateUser(ctx, value, fieldMask)
+	return p.impl.updateUser(ctx, value, fieldMask, opts...)
 }
 
 // Update a User. 'value' must at the least have
@@ -444,7 +444,7 @@ func (tx *TxPGClient) UpdateUser(
 	fieldMask pggen.FieldSet,
 	opts ...pggen.UpdateOpt,
 ) (ret int64, err error) {
-	return tx.impl.updateUser(ctx, value, fieldMask)
+	return tx.impl.updateUser(ctx, value, fieldMask, opts...)
 }
 
 // Update a User. 'value' must at the least have
@@ -458,7 +458,7 @@ func (conn *ConnPGClient) UpdateUser(
 	fieldMask pggen.FieldSet,
 	opts ...pggen.UpdateOpt,
 ) (ret int64, err error) {
-	return conn.impl.updateUser(ctx, value, fieldMask)
+	return conn.impl.updateUser(ctx, value, fieldMask, opts...)
 }
 func (p *pgClientImpl) updateUser(
 	ctx context.Context,
@@ -466,6 +466,12 @@ func (p *pgClientImpl) updateUser(
 	fieldMask pggen.FieldSet,
 	opts ...pggen.UpdateOpt,
 ) (ret int64, err error) {
+
+	opt := pggen.UpdateOptions{}
+	for _, o := range opts {
+		o(&opt)
+	}
+
 	if !fieldMask.Test(UserIdFieldIndex) {
 		return ret, p.client.errorConverter(fmt.Errorf(`primary key required for updates to 'users'`))
 	}

--- a/examples/query/models/pggen_prelude.gen.go
+++ b/examples/query/models/pggen_prelude.gen.go
@@ -7,10 +7,11 @@ import (
 	"database/sql"
 	"database/sql/driver"
 	"fmt"
-	"github.com/jackc/pgconn"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/jackc/pgconn"
 
 	"github.com/opendoor/pggen"
 )

--- a/examples/query_argument_names/models/models.gen.go
+++ b/examples/query_argument_names/models/models.gen.go
@@ -428,7 +428,7 @@ func (p *PGClient) UpdateUser(
 	fieldMask pggen.FieldSet,
 	opts ...pggen.UpdateOpt,
 ) (ret int64, err error) {
-	return p.impl.updateUser(ctx, value, fieldMask)
+	return p.impl.updateUser(ctx, value, fieldMask, opts...)
 }
 
 // Update a User. 'value' must at the least have
@@ -442,7 +442,7 @@ func (tx *TxPGClient) UpdateUser(
 	fieldMask pggen.FieldSet,
 	opts ...pggen.UpdateOpt,
 ) (ret int64, err error) {
-	return tx.impl.updateUser(ctx, value, fieldMask)
+	return tx.impl.updateUser(ctx, value, fieldMask, opts...)
 }
 
 // Update a User. 'value' must at the least have
@@ -456,7 +456,7 @@ func (conn *ConnPGClient) UpdateUser(
 	fieldMask pggen.FieldSet,
 	opts ...pggen.UpdateOpt,
 ) (ret int64, err error) {
-	return conn.impl.updateUser(ctx, value, fieldMask)
+	return conn.impl.updateUser(ctx, value, fieldMask, opts...)
 }
 func (p *pgClientImpl) updateUser(
 	ctx context.Context,
@@ -464,6 +464,12 @@ func (p *pgClientImpl) updateUser(
 	fieldMask pggen.FieldSet,
 	opts ...pggen.UpdateOpt,
 ) (ret int64, err error) {
+
+	opt := pggen.UpdateOptions{}
+	for _, o := range opts {
+		o(&opt)
+	}
+
 	if !fieldMask.Test(UserIdFieldIndex) {
 		return ret, p.client.errorConverter(fmt.Errorf(`primary key required for updates to 'users'`))
 	}

--- a/examples/query_argument_names/models/models.gen.go
+++ b/examples/query_argument_names/models/models.gen.go
@@ -6,12 +6,13 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"strings"
+	"sync"
+
 	"github.com/ethanpailes/pgtypes"
 	"github.com/opendoor/pggen"
 	"github.com/opendoor/pggen/include"
 	"github.com/opendoor/pggen/unstable"
-	"strings"
-	"sync"
 )
 
 // PGClient wraps either a 'sql.DB' or a 'sql.Tx'. All pggen-generated

--- a/examples/query_argument_names/models/pggen_prelude.gen.go
+++ b/examples/query_argument_names/models/pggen_prelude.gen.go
@@ -7,10 +7,11 @@ import (
 	"database/sql"
 	"database/sql/driver"
 	"fmt"
-	"github.com/jackc/pgconn"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/jackc/pgconn"
 
 	"github.com/opendoor/pggen"
 )

--- a/examples/single_results/models/models.gen.go
+++ b/examples/single_results/models/models.gen.go
@@ -6,12 +6,13 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"strings"
+	"sync"
+
 	"github.com/ethanpailes/pgtypes"
 	"github.com/opendoor/pggen"
 	"github.com/opendoor/pggen/include"
 	"github.com/opendoor/pggen/unstable"
-	"strings"
-	"sync"
 )
 
 // PGClient wraps either a 'sql.DB' or a 'sql.Tx'. All pggen-generated

--- a/examples/single_results/models/models.gen.go
+++ b/examples/single_results/models/models.gen.go
@@ -423,7 +423,7 @@ func (p *PGClient) UpdateFoo(
 	fieldMask pggen.FieldSet,
 	opts ...pggen.UpdateOpt,
 ) (ret int64, err error) {
-	return p.impl.updateFoo(ctx, value, fieldMask)
+	return p.impl.updateFoo(ctx, value, fieldMask, opts...)
 }
 
 // Update a Foo. 'value' must at the least have
@@ -437,7 +437,7 @@ func (tx *TxPGClient) UpdateFoo(
 	fieldMask pggen.FieldSet,
 	opts ...pggen.UpdateOpt,
 ) (ret int64, err error) {
-	return tx.impl.updateFoo(ctx, value, fieldMask)
+	return tx.impl.updateFoo(ctx, value, fieldMask, opts...)
 }
 
 // Update a Foo. 'value' must at the least have
@@ -451,7 +451,7 @@ func (conn *ConnPGClient) UpdateFoo(
 	fieldMask pggen.FieldSet,
 	opts ...pggen.UpdateOpt,
 ) (ret int64, err error) {
-	return conn.impl.updateFoo(ctx, value, fieldMask)
+	return conn.impl.updateFoo(ctx, value, fieldMask, opts...)
 }
 func (p *pgClientImpl) updateFoo(
 	ctx context.Context,
@@ -459,6 +459,12 @@ func (p *pgClientImpl) updateFoo(
 	fieldMask pggen.FieldSet,
 	opts ...pggen.UpdateOpt,
 ) (ret int64, err error) {
+
+	opt := pggen.UpdateOptions{}
+	for _, o := range opts {
+		o(&opt)
+	}
+
 	if !fieldMask.Test(FooIdFieldIndex) {
 		return ret, p.client.errorConverter(fmt.Errorf(`primary key required for updates to 'foos'`))
 	}

--- a/examples/single_results/models/pggen_prelude.gen.go
+++ b/examples/single_results/models/pggen_prelude.gen.go
@@ -7,10 +7,11 @@ import (
 	"database/sql"
 	"database/sql/driver"
 	"fmt"
-	"github.com/jackc/pgconn"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/jackc/pgconn"
 
 	"github.com/opendoor/pggen"
 )

--- a/examples/statement/models/models.gen.go
+++ b/examples/statement/models/models.gen.go
@@ -6,12 +6,13 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"strings"
+	"sync"
+
 	"github.com/ethanpailes/pgtypes"
 	"github.com/opendoor/pggen"
 	"github.com/opendoor/pggen/include"
 	"github.com/opendoor/pggen/unstable"
-	"strings"
-	"sync"
 )
 
 // PGClient wraps either a 'sql.DB' or a 'sql.Tx'. All pggen-generated

--- a/examples/statement/models/models.gen.go
+++ b/examples/statement/models/models.gen.go
@@ -426,7 +426,7 @@ func (p *PGClient) UpdateUser(
 	fieldMask pggen.FieldSet,
 	opts ...pggen.UpdateOpt,
 ) (ret int64, err error) {
-	return p.impl.updateUser(ctx, value, fieldMask)
+	return p.impl.updateUser(ctx, value, fieldMask, opts...)
 }
 
 // Update a User. 'value' must at the least have
@@ -440,7 +440,7 @@ func (tx *TxPGClient) UpdateUser(
 	fieldMask pggen.FieldSet,
 	opts ...pggen.UpdateOpt,
 ) (ret int64, err error) {
-	return tx.impl.updateUser(ctx, value, fieldMask)
+	return tx.impl.updateUser(ctx, value, fieldMask, opts...)
 }
 
 // Update a User. 'value' must at the least have
@@ -454,7 +454,7 @@ func (conn *ConnPGClient) UpdateUser(
 	fieldMask pggen.FieldSet,
 	opts ...pggen.UpdateOpt,
 ) (ret int64, err error) {
-	return conn.impl.updateUser(ctx, value, fieldMask)
+	return conn.impl.updateUser(ctx, value, fieldMask, opts...)
 }
 func (p *pgClientImpl) updateUser(
 	ctx context.Context,
@@ -462,6 +462,12 @@ func (p *pgClientImpl) updateUser(
 	fieldMask pggen.FieldSet,
 	opts ...pggen.UpdateOpt,
 ) (ret int64, err error) {
+
+	opt := pggen.UpdateOptions{}
+	for _, o := range opts {
+		o(&opt)
+	}
+
 	if !fieldMask.Test(UserIdFieldIndex) {
 		return ret, p.client.errorConverter(fmt.Errorf(`primary key required for updates to 'users'`))
 	}

--- a/examples/statement/models/pggen_prelude.gen.go
+++ b/examples/statement/models/pggen_prelude.gen.go
@@ -7,10 +7,11 @@ import (
 	"database/sql"
 	"database/sql/driver"
 	"fmt"
-	"github.com/jackc/pgconn"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/jackc/pgconn"
 
 	"github.com/opendoor/pggen"
 )

--- a/examples/timestamps/models/models.gen.go
+++ b/examples/timestamps/models/models.gen.go
@@ -6,13 +6,14 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"strings"
+	"sync"
+	"time"
+
 	"github.com/ethanpailes/pgtypes"
 	"github.com/opendoor/pggen"
 	"github.com/opendoor/pggen/include"
 	"github.com/opendoor/pggen/unstable"
-	"strings"
-	"sync"
-	"time"
 )
 
 // PGClient wraps either a 'sql.DB' or a 'sql.Tx'. All pggen-generated

--- a/examples/timestamps/models/models.gen.go
+++ b/examples/timestamps/models/models.gen.go
@@ -351,14 +351,16 @@ func (p *pgClientImpl) bulkInsertUser(
 	for _, o := range opts {
 		o(&opt)
 	}
-	now := time.Now()
-	for i := range values {
-		createdAt := now.UTC()
-		values[i].CreatedAt = createdAt
-	}
-	for i := range values {
-		updatedAt := now.UTC()
-		values[i].UpdatedAt = updatedAt
+	if !opt.DisableTimestamps {
+		now := time.Now()
+		for i := range values {
+			createdAt := now.UTC()
+			values[i].CreatedAt = createdAt
+		}
+		for i := range values {
+			updatedAt := now.UTC()
+			values[i].UpdatedAt = updatedAt
+		}
 	}
 
 	defaultFields := opt.DefaultFields.Intersection(defaultableColsForUser)
@@ -448,7 +450,7 @@ func (p *PGClient) UpdateUser(
 	fieldMask pggen.FieldSet,
 	opts ...pggen.UpdateOpt,
 ) (ret int64, err error) {
-	return p.impl.updateUser(ctx, value, fieldMask)
+	return p.impl.updateUser(ctx, value, fieldMask, opts...)
 }
 
 // Update a User. 'value' must at the least have
@@ -462,7 +464,7 @@ func (tx *TxPGClient) UpdateUser(
 	fieldMask pggen.FieldSet,
 	opts ...pggen.UpdateOpt,
 ) (ret int64, err error) {
-	return tx.impl.updateUser(ctx, value, fieldMask)
+	return tx.impl.updateUser(ctx, value, fieldMask, opts...)
 }
 
 // Update a User. 'value' must at the least have
@@ -476,7 +478,7 @@ func (conn *ConnPGClient) UpdateUser(
 	fieldMask pggen.FieldSet,
 	opts ...pggen.UpdateOpt,
 ) (ret int64, err error) {
-	return conn.impl.updateUser(ctx, value, fieldMask)
+	return conn.impl.updateUser(ctx, value, fieldMask, opts...)
 }
 func (p *pgClientImpl) updateUser(
 	ctx context.Context,
@@ -484,12 +486,20 @@ func (p *pgClientImpl) updateUser(
 	fieldMask pggen.FieldSet,
 	opts ...pggen.UpdateOpt,
 ) (ret int64, err error) {
+
+	opt := pggen.UpdateOptions{}
+	for _, o := range opts {
+		o(&opt)
+	}
+
 	if !fieldMask.Test(UserIdFieldIndex) {
 		return ret, p.client.errorConverter(fmt.Errorf(`primary key required for updates to 'users'`))
 	}
-	now := time.Now().UTC()
-	value.UpdatedAt = now
-	fieldMask.Set(UserUpdatedAtFieldIndex, true)
+	if !opt.DisableTimestamps {
+		now := time.Now().UTC()
+		value.UpdatedAt = now
+		fieldMask.Set(UserUpdatedAtFieldIndex, true)
+	}
 
 	updateStmt := genUpdateStmt(
 		`users`,
@@ -662,16 +672,18 @@ func (p *pgClientImpl) bulkUpsertUser(
 		constraintNames = []string{`id`}
 	}
 
-	now := time.Now()
-	createdAt := now.UTC()
-	for i := range values {
-		values[i].CreatedAt = createdAt
+	if !options.DisableTimestamps {
+		now := time.Now()
+		createdAt := now.UTC()
+		for i := range values {
+			values[i].CreatedAt = createdAt
+		}
+		updatedAt := now.UTC()
+		for i := range values {
+			values[i].UpdatedAt = updatedAt
+		}
+		fieldMask.Set(UserUpdatedAtFieldIndex, true)
 	}
-	updatedAt := now.UTC()
-	for i := range values {
-		values[i].UpdatedAt = updatedAt
-	}
-	fieldMask.Set(UserUpdatedAtFieldIndex, true)
 
 	defaultFields := options.DefaultFields.Intersection(defaultableColsForUser)
 	var stmt strings.Builder

--- a/examples/timestamps/models/pggen_prelude.gen.go
+++ b/examples/timestamps/models/pggen_prelude.gen.go
@@ -7,10 +7,11 @@ import (
 	"database/sql"
 	"database/sql/driver"
 	"fmt"
-	"github.com/jackc/pgconn"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/jackc/pgconn"
 
 	"github.com/opendoor/pggen"
 )

--- a/examples/upsert/models/models.gen.go
+++ b/examples/upsert/models/models.gen.go
@@ -6,12 +6,13 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"strings"
+	"sync"
+
 	"github.com/ethanpailes/pgtypes"
 	"github.com/opendoor/pggen"
 	"github.com/opendoor/pggen/include"
 	"github.com/opendoor/pggen/unstable"
-	"strings"
-	"sync"
 )
 
 // PGClient wraps either a 'sql.DB' or a 'sql.Tx'. All pggen-generated

--- a/examples/upsert/models/models.gen.go
+++ b/examples/upsert/models/models.gen.go
@@ -431,7 +431,7 @@ func (p *PGClient) UpdateUser(
 	fieldMask pggen.FieldSet,
 	opts ...pggen.UpdateOpt,
 ) (ret int64, err error) {
-	return p.impl.updateUser(ctx, value, fieldMask)
+	return p.impl.updateUser(ctx, value, fieldMask, opts...)
 }
 
 // Update a User. 'value' must at the least have
@@ -445,7 +445,7 @@ func (tx *TxPGClient) UpdateUser(
 	fieldMask pggen.FieldSet,
 	opts ...pggen.UpdateOpt,
 ) (ret int64, err error) {
-	return tx.impl.updateUser(ctx, value, fieldMask)
+	return tx.impl.updateUser(ctx, value, fieldMask, opts...)
 }
 
 // Update a User. 'value' must at the least have
@@ -459,7 +459,7 @@ func (conn *ConnPGClient) UpdateUser(
 	fieldMask pggen.FieldSet,
 	opts ...pggen.UpdateOpt,
 ) (ret int64, err error) {
-	return conn.impl.updateUser(ctx, value, fieldMask)
+	return conn.impl.updateUser(ctx, value, fieldMask, opts...)
 }
 func (p *pgClientImpl) updateUser(
 	ctx context.Context,
@@ -467,6 +467,12 @@ func (p *pgClientImpl) updateUser(
 	fieldMask pggen.FieldSet,
 	opts ...pggen.UpdateOpt,
 ) (ret int64, err error) {
+
+	opt := pggen.UpdateOptions{}
+	for _, o := range opts {
+		o(&opt)
+	}
+
 	if !fieldMask.Test(UserIdFieldIndex) {
 		return ret, p.client.errorConverter(fmt.Errorf(`primary key required for updates to 'users'`))
 	}

--- a/examples/upsert/models/pggen_prelude.gen.go
+++ b/examples/upsert/models/pggen_prelude.gen.go
@@ -7,10 +7,11 @@ import (
 	"database/sql"
 	"database/sql/driver"
 	"fmt"
-	"github.com/jackc/pgconn"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/jackc/pgconn"
 
 	"github.com/opendoor/pggen"
 )

--- a/examples/uuid/models/models.gen.go
+++ b/examples/uuid/models/models.gen.go
@@ -427,7 +427,7 @@ func (p *PGClient) UpdateUser(
 	fieldMask pggen.FieldSet,
 	opts ...pggen.UpdateOpt,
 ) (ret int64, err error) {
-	return p.impl.updateUser(ctx, value, fieldMask)
+	return p.impl.updateUser(ctx, value, fieldMask, opts...)
 }
 
 // Update a User. 'value' must at the least have
@@ -441,7 +441,7 @@ func (tx *TxPGClient) UpdateUser(
 	fieldMask pggen.FieldSet,
 	opts ...pggen.UpdateOpt,
 ) (ret int64, err error) {
-	return tx.impl.updateUser(ctx, value, fieldMask)
+	return tx.impl.updateUser(ctx, value, fieldMask, opts...)
 }
 
 // Update a User. 'value' must at the least have
@@ -455,7 +455,7 @@ func (conn *ConnPGClient) UpdateUser(
 	fieldMask pggen.FieldSet,
 	opts ...pggen.UpdateOpt,
 ) (ret int64, err error) {
-	return conn.impl.updateUser(ctx, value, fieldMask)
+	return conn.impl.updateUser(ctx, value, fieldMask, opts...)
 }
 func (p *pgClientImpl) updateUser(
 	ctx context.Context,
@@ -463,6 +463,12 @@ func (p *pgClientImpl) updateUser(
 	fieldMask pggen.FieldSet,
 	opts ...pggen.UpdateOpt,
 ) (ret int64, err error) {
+
+	opt := pggen.UpdateOptions{}
+	for _, o := range opts {
+		o(&opt)
+	}
+
 	if !fieldMask.Test(UserIdFieldIndex) {
 		return ret, p.client.errorConverter(fmt.Errorf(`primary key required for updates to 'users'`))
 	}

--- a/examples/uuid/models/models.gen.go
+++ b/examples/uuid/models/models.gen.go
@@ -6,13 +6,14 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"strings"
+	"sync"
+
 	"github.com/ethanpailes/pgtypes"
 	"github.com/gofrs/uuid"
 	"github.com/opendoor/pggen"
 	"github.com/opendoor/pggen/include"
 	"github.com/opendoor/pggen/unstable"
-	"strings"
-	"sync"
 )
 
 // PGClient wraps either a 'sql.DB' or a 'sql.Tx'. All pggen-generated

--- a/examples/uuid/models/pggen_prelude.gen.go
+++ b/examples/uuid/models/pggen_prelude.gen.go
@@ -7,10 +7,11 @@ import (
 	"database/sql"
 	"database/sql/driver"
 	"fmt"
-	"github.com/jackc/pgconn"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/jackc/pgconn"
 
 	"github.com/opendoor/pggen"
 )

--- a/gen/gen_table.go
+++ b/gen/gen_table.go
@@ -465,7 +465,6 @@ func (p *pgClientImpl) update{{ .GoName }}(
 	fieldMask pggen.FieldSet,
 	opts ...pggen.UpdateOpt,
 ) (ret {{ .PkeyCol.TypeInfo.Name }}, err error) {
-
 	opt := pggen.UpdateOptions{}
 	for _, o := range opts {
 		o(&opt)

--- a/options.go
+++ b/options.go
@@ -4,8 +4,8 @@ package pggen
 
 type InsertOpt func(opts *InsertOptions)
 type InsertOptions struct {
-	UsePkey       bool
-	DefaultFields FieldSet
+	UsePkey           bool
+	DefaultFields     FieldSet
 	DisableTimestamps bool
 }
 
@@ -34,8 +34,8 @@ func InsertDefaultFields(fieldSet FieldSet) InsertOpt {
 
 type UpsertOpt func(opts *UpsertOptions)
 type UpsertOptions struct {
-	UsePkey       bool
-	DefaultFields FieldSet
+	UsePkey           bool
+	DefaultFields     FieldSet
 	DisableTimestamps bool
 }
 

--- a/options.go
+++ b/options.go
@@ -6,6 +6,13 @@ type InsertOpt func(opts *InsertOptions)
 type InsertOptions struct {
 	UsePkey       bool
 	DefaultFields FieldSet
+	DisableTimestamps bool
+}
+
+// InsertDisableTimestamps tells an insert method to not
+// set the timestamp fields
+func InsertDisableTimestamps(opts *InsertOptions) {
+	opts.DisableTimestamps = true
 }
 
 // InsertUsePkey tells an insert method to insert the primary key into the database
@@ -29,6 +36,13 @@ type UpsertOpt func(opts *UpsertOptions)
 type UpsertOptions struct {
 	UsePkey       bool
 	DefaultFields FieldSet
+	DisableTimestamps bool
+}
+
+// UpsertDisableTimestamps tells an upsert method to not
+// set the timestamp fields
+func UpsertDisableTimestamps(opts *UpsertOptions) {
+	opts.DisableTimestamps = true
 }
 
 // UpsertUsePkey tells an upsert method to insert the primary key into the database
@@ -71,6 +85,13 @@ func DeleteDoHardDelete(opts *DeleteOptions) {
 
 type UpdateOpt func(opts *UpdateOptions)
 type UpdateOptions struct {
+	DisableTimestamps bool
+}
+
+// UpdateDisableTimestamps tells an update method to not
+// set the timestamp fields
+func UpdateDisableTimestamps(opts *UpdateOptions) {
+	opts.DisableTimestamps = true
 }
 
 type IncludeOpt func(opts *IncludeOptions)


### PR DESCRIPTION
In certain scenarios we want to disable the automatic timestamp tracking.

E.g if we are creating a backfill and want to backdate the created_at field 