### PR TITLE
fix statment comments to allow multiple lines

### DIFF
--- a/gen/gen_stmt.go
+++ b/gen/gen_stmt.go
@@ -42,7 +42,7 @@ func (g *Generator) genStmt(into io.Writer, stmt *config.StmtConfig) error {
 }
 
 var stmtShimTmpl *template.Template = template.Must(template.New("stmt-shim").Parse(`
-{{ if .ConfigData.Comment}}// {{ .ConfigData.Comment }}{{ end }}
+{{ .Comment }}
 func (p *PGClient) {{ .ConfigData.Name }}(
 	ctx context.Context,
 	{{- range .Args}}
@@ -60,7 +60,7 @@ func (p *PGClient) {{ .ConfigData.Name }}(
 		{{- end}}
 	)
 }
-{{ if .ConfigData.Comment}}// {{ .ConfigData.Comment }}{{ end }}
+{{ .Comment }}
 func (tx *TxPGClient) {{ .ConfigData.Name }}(
 	ctx context.Context,
 	{{- range .Args}}
@@ -78,7 +78,7 @@ func (tx *TxPGClient) {{ .ConfigData.Name }}(
 		{{- end}}
 	)
 }
-{{ if .ConfigData.Comment}}// {{ .ConfigData.Comment }}{{ end }}
+{{ .Comment }}
 func (conn *ConnPGClient) {{ .ConfigData.Name }}(
 	ctx context.Context,
 	{{- range .Args}}

--- a/gen/internal/meta/meta.go
+++ b/gen/internal/meta/meta.go
@@ -169,6 +169,8 @@ func (mc *Resolver) QueryMeta(
 type StmtMeta struct {
 	// The configuation data for this stmt from the .toml file
 	ConfigData config.StmtConfig
+	// The comment as it should be emitted in the generated code
+	Comment string
 	// The metadata for the arguments to this query
 	Args []Arg
 }
@@ -177,6 +179,8 @@ func (mc *Resolver) StmtMeta(
 	config *config.StmtConfig,
 ) (ret StmtMeta, err error) {
 	ret.ConfigData = *config
+
+	ret.Comment = configCommentToGoComment(config.Comment)
 
 	args, err := mc.argsOfStmt(config.Body, config.ArgNames)
 	if err != nil {


### PR DESCRIPTION
I realized the way I first did it would only work for
one line. Whoops.